### PR TITLE
Have URLs pointing to to github

### DIFF
--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -21,8 +21,8 @@
       "large": "http://www.instana.com/media/instana_icon_square.png"
     },
     "links": [
-      {"name": "GitHub", "url": "https://instana.com" },
-      {"name": "MIT License", "url": "https://instana.com" }
+      {"name": "GitHub", "url": "https://instana.co://github.com/instana/instana-grafana-datasource" },
+      {"name": "MIT License", "url": "https://raw.githubusercontent.com/instana/instana-grafana-datasource/master/LICENSE" }
     ],
     "version": "1.0.1",
     "updated": "2018-03-07"


### PR DESCRIPTION
This is a proposed fix for the URLs in the instana-grafana plugin
Github points to github, obviously.
License also, as a deep-link to the license file
HTH