### PR TITLE
Add groupbyTagSecondLevelKey for analyze application calls

### DIFF
--- a/src/datasource_application.ts
+++ b/src/datasource_application.ts
@@ -51,7 +51,8 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
     const windowSize = this.getWindowSize(timeFilter);
     const data: CallGroupBody = {
       group: {
-        groupbyTag: 'application.name'
+        groupbyTag: 'application.name',
+        groupbyTagSecondLevelKey: ''
       },
       timeFrame: {
         to: timeFilter.to,
@@ -159,9 +160,15 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
       metric['granularity'] = this.getChartGranularity(windowSize);
     }
 
+    let groupbyTagSecondLevelKey = "";
+    if (target.group.key === "call.http.header"){
+      groupbyTagSecondLevelKey = target.groupbyTagSecondLevelKey;
+    }
+
     const data: CallGroupBody = {
       group: {
-        groupbyTag: target.group.key
+        groupbyTag: target.group.key,
+        groupbyTagSecondLevelKey
       },
       timeFrame: {
         to: timeFilter.to,

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -296,6 +296,15 @@
                   ng-options="f as f.key for f in ctrl.uniqueTags track by f.key">
           </select>
         </div>
+        <input id="group-by-seconde-level-{{ctrl.target.refId}}"
+               ng-hide="!ctrl.target.showApplicationGroupBySecondeLevel"
+               class="gf-form-input width-22"
+               type="text"
+               ng-model='ctrl.target.groupbyTagSecondLevelKey'
+               ng-model-options='{ debounce: 300 }'
+               ng-change="ctrl.onChange()"
+               placeholder="Please Specify"
+               spellcheck='false'/>
       </div>
   </script>
 

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -415,6 +415,7 @@ export class InstanaQueryCtrl extends QueryCtrl {
   }
 
   onChange() {
+    this.target.showApplicationGroupBySecondeLevel = (this.target.group.key === "call.http.header");
     this.panelCtrl.refresh();
   }
 

--- a/src/types/call_group_body.ts
+++ b/src/types/call_group_body.ts
@@ -1,5 +1,6 @@
 export interface Group {
   groupbyTag: string;
+  groupbyTagSecondLevelKey: string;
 }
 
 export interface TimeFrame {


### PR DESCRIPTION
Hi,

for one of our usecases we need to add the `groupbyTagSecondLevelKey` attribute for the `call.http.header` tag. This was not possible. I have copy-pasted the logic from the `beacon.meta` logic and it is working so far in my test setup.

I'm not familiar on writing grafana plugins nor angular, so if something in my patch is not by the book, please bear with me.

It would be very nice to have this feature in the official distribution, if we can help on achieving this, feel free to get back in touch with us.

Greetings from Düsseldorf,
Tristan