### PR TITLE
Fix second level grouping

### DIFF
--- a/src/datasource_application.ts
+++ b/src/datasource_application.ts
@@ -154,7 +154,7 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
     const group = {
       groupbyTag: target.group.key
     };
-    if (target.group.key === "call.http.header" && target.groupbyTagSecondLevelKey) {
+    if (target.group.type === "KEY_VALUE_PAIR" && target.groupbyTagSecondLevelKey) {
       group['groupbyTagSecondLevelKey'] = target.groupbyTagSecondLevelKey;
     }
 

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -420,7 +420,7 @@
         </div>
         <input id="group-by-second-level-{{ctrl.target.refId}}"
                ng-hide="!ctrl.target.showGroupBySecondLevel"
-               class="gf-form-input width-22"
+               class="gf-form-input min-width-12"
                type="text"
                ng-model='ctrl.target.groupbyTagSecondLevelKey'
                ng-model-options='{ debounce: 500 }'

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -610,7 +610,8 @@ export class InstanaQueryCtrl extends QueryCtrl {
 
   onGroupChange() {
     if (this.target.group && this.isAnalyzeApplication()) {
-      this.target.showGroupBySecondLevel = this.target.group.key === 'call.http.header';
+      //this.target.showGroupBySecondLevel = this.target.group.key === 'call.http.header';
+      this.target.showGroupBySecondLevel = this.target.group.type === 'KEY_VALUE_PAIR';
     } else if (this.target.group && this.isAnalyzeWebsite()) {
       this.target.showGroupBySecondLevel = this.target.group.key === 'beacon.meta';
     }


### PR DESCRIPTION
This PR allows the user to provide a second level grouping on each group where `group.type` equals "KEY_VALUE_PAIR". It also makes the input field in which second levels groupings are entered appear bigger for more convenience. 

Thanks to @asafarian for the concrete implementation improvement.