### PR TITLE
Fix bug that automatically enables proxy config

### DIFF
--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -11,6 +11,11 @@ export class InstanaConfigCtrl {
 
     // check possibility every time
     this.current.jsonData.canUseProxy = proxy_check();
+
+    if (this.current.jsonData.useProxy === undefined) {
+      this.current.jsonData.useProxy = proxy_check();
+    }
+
     this.detectFeatures();
   }
 

--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -12,7 +12,7 @@ export class InstanaConfigCtrl {
     // check possibility every time
     this.current.jsonData.canUseProxy = proxy_check();
 
-    this.current.jsonData.useProxy = this.current.jsonData.useProxy || proxy_check();
+    //this.current.jsonData.useProxy = this.current.jsonData.useProxy || proxy_check();
     this.detectFeatures();
   }
 

--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -11,8 +11,6 @@ export class InstanaConfigCtrl {
 
     // check possibility every time
     this.current.jsonData.canUseProxy = proxy_check();
-
-    //this.current.jsonData.useProxy = this.current.jsonData.useProxy || proxy_check();
     this.detectFeatures();
   }
 


### PR DESCRIPTION
Currently (2.4.1), when one configures an Instana Datasource in Grafana to not use a proxy, the next time one enters the settings view it is enabled again.

This PR fixes this behaviour by not setting the proxy in the constructor.

This PR refers to: [Ticket 9972](https://instana.zendesk.com/agent/tickets/9972)