### PR TITLE
Added feature for query interval limits on different plugin datasourc…

### DIFF
--- a/src/datasource_abstract.ts
+++ b/src/datasource_abstract.ts
@@ -30,7 +30,6 @@ export default class AbstractDatasource {
   constructor(instanceSettings, public backendSrv, public templateSrv, public $q) {
     this.name = instanceSettings.name;
     this.id = instanceSettings.id;
-
     this.simpleCache = new Cache<Array<Selectable>>();
 
     // old versions have not saved proxy usage, so we switch to the default assumption
@@ -112,4 +111,25 @@ export default class AbstractDatasource {
     }]);
   }
 
+  isValidQueryInterval(windowSizeForQuery: number, queryintervalLimit: number ): boolean {
+    if (!((queryintervalLimit === undefined || queryintervalLimit == null || queryintervalLimit <= 0))){
+      return windowSizeForQuery <= queryintervalLimit;
+    }
+    return true;
+  }
+
+  checkValidQueryIntervalWithException(windowSizeForQuery: number, queryintervalLimit: number ) {
+    if (!this.isValidQueryInterval(windowSizeForQuery,queryintervalLimit)){
+        throw new Error("Limit for query time windowsize exceeded. Maximum is defined in config as: "+
+          queryintervalLimit+" / requested Windowsize: "+windowSizeForQuery);
+    }
+  }
+
+
+  fromHourToMS(queryintervalLimitInHours: any) {
+    if (!((queryintervalLimitInHours === undefined || queryintervalLimitInHours == null || queryintervalLimitInHours <= 0))){
+      return queryintervalLimitInHours * 60 * 60 * 1000;
+    }
+    return 0;
+  }
 }

--- a/src/datasource_application.ts
+++ b/src/datasource_application.ts
@@ -11,6 +11,8 @@ import _ from 'lodash';
 
 export default class InstanaApplicationDataSource extends AbstractDatasource {
   applicationsCache: Cache<Promise<Array<Selectable>>>;
+  queryInvervallAppCallsLimit: number;
+  queryInvervallAppMetricLimit: number;
 
   // our ui is limited to 80 results, same logic to stay comparable
   maximumNumberOfUsefulDataPoints = 80;
@@ -21,8 +23,9 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
   /** @ngInject */
   constructor(instanceSettings, backendSrv, templateSrv, $q) {
     super(instanceSettings, backendSrv, templateSrv, $q);
-
     this.applicationsCache = new Cache<Promise<Array<Selectable>>>();
+    this.queryInvervallAppCallsLimit = super.fromHourToMS(instanceSettings.jsonData.queryinterval_limit_app_calls);
+    this.queryInvervallAppMetricLimit = super.fromHourToMS(instanceSettings.jsonData.queryinterval_limit_app_metrics);
   }
 
   getApplications(timeFilter: TimeFilter) {
@@ -116,13 +119,15 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
   }
 
   fetchAnalyzeMetricsForApplication(target, timeFilter: TimeFilter) {
-    // avoid invalid calls
-    if (!target || !target.metric || !target.group || !target.entity) {
-      return this.$q.resolve({data: {items: []}});
-    }
-
     // our is limited to maximumNumberOfUsefulDataPoints results, to stay comparable
     const windowSize = this.getWindowSize(timeFilter);
+
+    // check if valid Query Interval
+    super.checkValidQueryIntervalWithException(windowSize, this.queryInvervallAppCallsLimit);
+
+    if (!target || !target.metric || !target.group || !target.entity ) {
+      return this.$q.resolve({data: {items: []}});
+    }
 
     const tagFilters = [];
 
@@ -178,6 +183,9 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
     }
 
     const windowSize = this.getWindowSize(timeFilter);
+
+    // check if valid Query Interval
+    super.checkValidQueryIntervalWithException(windowSize, this.queryInvervallAppMetricLimit);
 
     const metric = {
       metric: target.metric.key,

--- a/src/datasource_endpoint.ts
+++ b/src/datasource_endpoint.ts
@@ -11,6 +11,7 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
   endpointsCache: Cache<Promise<Array<Selectable>>>;
   serviceDataSource: InstanaServiceDataSource;
   maximumNumberOfUsefulDataPoints = 80;
+  queryInvervallLimit: number;
 
   // duplicate to QueryCtrl.ALL_ENDPOINTS
   ALL_ENDPOINTS = '-- No Endpoint Filter --';
@@ -21,6 +22,7 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
 
     this.serviceDataSource = serviceDataSource;
     this.endpointsCache = new Cache<Promise<Array<Selectable>>>();
+    this.queryInvervallLimit = super.fromHourToMS(instanceSettings.jsonData.queryinterval_limit_endpoint_metrics);
   }
 
   getEndpoints(target, timeFilter: TimeFilter) {
@@ -120,6 +122,8 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
     }
 
     const windowSize = this.getWindowSize(timeFilter);
+    // check if valid Query Interval
+    super.checkValidQueryIntervalWithException(windowSize, this.queryInvervallLimit);
 
     const metric = {
       metric: target.metric.key,

--- a/src/datasource_infrastructure.ts
+++ b/src/datasource_infrastructure.ts
@@ -11,8 +11,8 @@ export default class InstanaInfrastructureDataSource extends AbstractDatasource 
   snapshotInfoCache: Cache<Promise<Array<Selectable>>>;
   catalogCache: Cache<Promise<Array<Selectable>>>;
   showOffline: boolean;
-
   timeToLiveSnapshotInfoCache = 60*60*1000;
+  queryInvervallLimit: number;
 
   /** @ngInject */
   constructor(instanceSettings, backendSrv, templateSrv, $q) {
@@ -23,6 +23,7 @@ export default class InstanaInfrastructureDataSource extends AbstractDatasource 
     this.snapshotCache = new Cache<Promise<Array<Selectable>>>();
     this.snapshotInfoCache = new Cache<Promise<Array<Selectable>>>();
     this.catalogCache = new Cache<Promise<Array<Selectable>>>();
+    this.queryInvervallLimit = super.fromHourToMS(instanceSettings.jsonData.queryinterval_limit_infra);
   }
 
   getEntityTypes() {
@@ -81,6 +82,10 @@ export default class InstanaInfrastructureDataSource extends AbstractDatasource 
     if (snapshots) {
       return snapshots;
     }
+
+    const windowSize = this.getWindowSize(timeFilter);
+    // check if valid Query Interval
+    super.checkValidQueryIntervalWithException(windowSize, this.queryInvervallLimit);
 
     const fetchSnapshotContextsUrl = `/api/snapshots/context` +
       `?q=${query}` +
@@ -173,6 +178,10 @@ export default class InstanaInfrastructureDataSource extends AbstractDatasource 
   }
 
   fetchMetricsForSnapshots(target, snapshots, timeFilter: TimeFilter, metric) {
+    const windowSize = this.getWindowSize(timeFilter);
+    // check if valid Query Interval
+    super.checkValidQueryIntervalWithException(windowSize, this.queryInvervallLimit);
+
     return this.$q.all(
       _.map(snapshots, (snapshot, index) => {
         // ...fetch the metric data for every snapshot in the results.

--- a/src/datasource_service.ts
+++ b/src/datasource_service.ts
@@ -10,6 +10,7 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
   servicesCache: Cache<Promise<Array<Selectable>>>;
 
   maximumNumberOfUsefulDataPoints = 80;
+  queryInvervallLimit: number;
 
   // duplicate to QueryCtrl.ALL_SERVICES
   ALL_SERVICES = '-- No Service Filter --';
@@ -19,6 +20,7 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
     super(instanceSettings, backendSrv, templateSrv, $q);
 
     this.servicesCache = new Cache<Promise<Array<Selectable>>>();
+    this.queryInvervallLimit = super.fromHourToMS(instanceSettings.jsonData.queryinterval_limit_service_metrics);
   }
 
   getServices(target, timeFilter: TimeFilter) {
@@ -109,6 +111,8 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
     }
 
     const windowSize = this.getWindowSize(timeFilter);
+    // check if valid Query Interval
+    super.checkValidQueryIntervalWithException(windowSize, this.queryInvervallLimit);
 
     const metric = {
       metric: target.metric.key,

--- a/src/datasource_website.ts
+++ b/src/datasource_website.ts
@@ -13,12 +13,14 @@ export default class InstanaWebsiteDataSource extends AbstractDatasource {
 
   // our ui is limited to 80 results, same logic to stay comparable
   maximumNumberOfUsefulDataPoints = 80;
+  queryInvervallLimit: number;
 
   /** @ngInject */
   constructor(instanceSettings, backendSrv, templateSrv, $q) {
     super(instanceSettings, backendSrv, templateSrv, $q);
 
     this.websitesCache = new Cache<Promise<Array<Selectable>>>();
+    this.queryInvervallLimit = super.fromHourToMS(instanceSettings.jsonData.queryinterval_limit_website_metrics);
   }
 
   getWebsites(timeFilter: TimeFilter) {
@@ -108,6 +110,8 @@ export default class InstanaWebsiteDataSource extends AbstractDatasource {
     }
 
     const windowSize = this.getWindowSize(timeFilter);
+    // check if valid Query Interval
+    super.checkValidQueryIntervalWithException(windowSize, this.queryInvervallLimit);
 
     const tagFilters = [{
       name: 'beacon.website.name',

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -37,4 +37,67 @@
     </label>
     <gf-form-switch class="gf-form-switch" id="in-historic-mode" checked="ctrl.current.jsonData.showOffline" ng-disabled="!ctrl.current.jsonData.canQueryOfflineSnapshots"/>
   </div>
+  <div class="gf-form">
+    <label class="gf-form-label width-14 pointer">
+      Max. query-interval in hours
+      <info-popover position="top center" mode="right-normal">
+        <p>This Settings are optional values to control the load of data queries, by defining the maximum allowed query intervals on a Instana Server.</p>
+      </info-popover>
+    </label>
+  </div>
+  <div class="gf-form">
+    <label class="gf-form-label width-14 pointer" for="in-queryinterval-infra">
+      Infrastructure metrics
+      <info-popover position="top center" mode="right-normal">
+        <p>Limit for max. query interval in hours for Category: Infrastructure metrics</p>
+      </info-popover>
+    </label>
+    <input class="gf-form-input width-30" id="in-queryinterval-infra" type="text" ng-model="ctrl.current.jsonData.queryinterval_limit_infra" ng-change="ctrl.onAccessChange()" placeholder="optional: interval limit in hours"></input>
+  </div>
+
+  <div class="gf-form">
+    <label class="gf-form-label width-14 pointer" for="in-queryinterval-app-metrics">
+      Application metrics
+      <info-popover position="top center" mode="right-normal">
+        <p>Limit for max. query interval in hours for Category: Application metrics</p>
+      </info-popover>
+    </label>
+    <input class="gf-form-input width-30" id="in-queryinterval-app-metrics" type="text" ng-model="ctrl.current.jsonData.queryinterval_limit_app_metrics" ng-change="ctrl.onAccessChange()" placeholder="optional: interval limit in hours"></input>
+  </div>
+  <div class="gf-form">
+    <label class="gf-form-label width-14 pointer" for="in-queryinterval-service-metrics">
+      Service metrics
+      <info-popover position="top center" mode="right-normal">
+        <p>Limit for max. query interval in hours for Category: Service metrics</p>
+      </info-popover>
+    </label>
+    <input class="gf-form-input width-30" id="in-queryinterval-service-metrics" type="text" ng-model="ctrl.current.jsonData.queryinterval_limit_service_metrics" ng-change="ctrl.onAccessChange()" placeholder="optional: interval limit in hours"></input>
+  </div>
+  <div class="gf-form">
+    <label class="gf-form-label width-14 pointer" for="in-queryinterval-endpoint-metrics">
+      Endpoint metrics
+      <info-popover position="top center" mode="right-normal">
+        <p>Limit for max. query interval in hours for Category: Endpoint metrics</p>
+      </info-popover>
+    </label>
+    <input class="gf-form-input width-30" id="in-queryinterval-endpoint-metrics" type="text" ng-model="ctrl.current.jsonData.queryinterval_limit_endpoint_metrics" ng-change="ctrl.onAccessChange()" placeholder="optional: interval limit in hours"></input>
+  </div>
+  <div class="gf-form">
+    <label class="gf-form-label width-14 pointer" for="in-queryinterval-app-calls">
+      Analyze application calls
+      <info-popover position="top center" mode="right-normal">
+        <p>Limit for max. query interval in hours for Category: Infrastructure custom metrics</p>
+      </info-popover>
+    </label>
+    <input class="gf-form-input width-30" id="in-queryinterval-app-calls" type="text" ng-model="ctrl.current.jsonData.queryinterval_limit_app_calls" ng-change="ctrl.onAccessChange()" placeholder="optional: interval limit in hours"></input>
+  </div>
+  <div class="gf-form">
+    <label class="gf-form-label width-14 pointer" for="in-queryinterval-website">
+      Website Metrics
+      <info-popover position="top center" mode="right-normal">
+        <p>Limit for max. query interval in hours for Category: Website metrics</p>
+      </info-popover>
+    </label>
+    <input class="gf-form-input width-30" id="in-queryinterval-website" type="text" ng-model="ctrl.current.jsonData.queryinterval_limit_website_metrics" ng-change="ctrl.onAccessChange()" placeholder="optional: interval limit in hours"></input>
+  </div>
 </div>


### PR DESCRIPTION
This Feature enables administrators of grafana to reduce query load for queries with wide query time ranges. Wide query time ranges put an extra load to components like clickhouse, which will affect the instana UI app perspectives.
Please have a look. I am looking forward to your feedback.