### PR TITLE
Refactor application service endpoint category to one view

### DIFF
--- a/specs/add_datasource_specs.js
+++ b/specs/add_datasource_specs.js
@@ -17,7 +17,7 @@ describe('When adding the Instana datasource to Grafana', function() {
     await page.waitFor(500);
 
     await page.goto('http://localhost:3000/login');
-    await page.type('input[name=username]', 'admin');
+    await page.type('input[name=user]', 'admin');
     await page.type('input[name=password]', 'admin');
     const logInButton = await page.waitForXPath('//button[contains(text(),"Log In")]');
     logInButton.click();

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -296,20 +296,44 @@ export default class InstanaDatasource extends AbstractDatasource {
   }
 
   getApplicationServiceEndpointMetrics(target, timeFilter: TimeFilter) {
-    if (target.entity && !target.service && !target.endpoint) {
+    if (this.isApplicationSet(target.entity) && !this.isServiceSet(target.service) && !this.isEndpointSet(target.endpoint)) {
+      console.log("application");
       return this.application.fetchApplicationMetrics(target, timeFilter).then(response => {
         target.showWarningCantShowAllResults = response.data.canLoadMore;
         return readItemMetrics(target, response, this.application.buildApplicationMetricLabel);
       });
-    } else if (target.entity && target.service && !target.endpoint) {
+    } else if (this.isApplicationSet(target.entity) && this.isServiceSet(target.service) && !this.isEndpointSet(target.endpoint)) {
+      console.log("application and service");
       return this.service.fetchServiceMetrics(target, timeFilter).then(response => {
         return readItemMetrics(target, response, this.service.buildServiceMetricLabel);
       });
-    } else if (target.entity && target.service && target.endpoint) {
+    } else if (this.isApplicationSet(target.entity) && this.isServiceSet(target.service) && this.isEndpointSet(target.endpoint)) {
+      console.log("application and service and endpoint");
       return  this.endpoint.fetchEndpointMetrics(target, timeFilter).then(response => {
         return readItemMetrics(target, response, this.endpoint.buildEndpointMetricLabel);
       });
     }
+  }
+
+  isApplicationSet(application) {
+    if (application && application.key) {
+      return true;
+    }
+    return false;
+  }
+
+  isServiceSet(service) {
+    if (service && service.key) {
+      return true;
+    }
+    return false;
+  }
+
+  isEndpointSet(endpoint) {
+    if (endpoint && endpoint.key) {
+      return true;
+    }
+    return false;
   }
 
   annotationQuery(options) {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -296,21 +296,17 @@ export default class InstanaDatasource extends AbstractDatasource {
   }
 
   getApplicationServiceEndpointMetrics(target, timeFilter: TimeFilter) {
-    console.log("wants to fetch metrics");
     if (this.isEndpointSet(target.endpoint)) {
       //endpoint metrics
-      console.log("wants to fetch endpoint metrics");
       return  this.endpoint.fetchEndpointMetrics(target, timeFilter).then(response => {
         return readItemMetrics(target, response, this.endpoint.buildEndpointMetricLabel);
       });
     } else if (this.isServiceSet(target.service)) {
-      //service metrics
-      console.log("wants to fetch service metrics");
+      //service
       return this.service.fetchServiceMetrics(target, timeFilter).then(response => {
         return readItemMetrics(target, response, this.service.buildServiceMetricLabel);
       });
     } else if (this.isApplicationSet(target.entity)) {
-      console.log("wants to fetch application metrics");
       return this.application.fetchApplicationMetrics(target, timeFilter).then(response => {
         target.showWarningCantShowAllResults = response.data.canLoadMore;
         return readItemMetrics(target, response, this.application.buildApplicationMetricLabel);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -296,17 +296,21 @@ export default class InstanaDatasource extends AbstractDatasource {
   }
 
   getApplicationServiceEndpointMetrics(target, timeFilter: TimeFilter) {
+    console.log("wants to fetch metrics");
     if (this.isEndpointSet(target.endpoint)) {
       //endpoint metrics
+      console.log("wants to fetch endpoint metrics");
       return  this.endpoint.fetchEndpointMetrics(target, timeFilter).then(response => {
         return readItemMetrics(target, response, this.endpoint.buildEndpointMetricLabel);
       });
     } else if (this.isServiceSet(target.service)) {
       //service metrics
+      console.log("wants to fetch service metrics");
       return this.service.fetchServiceMetrics(target, timeFilter).then(response => {
         return readItemMetrics(target, response, this.service.buildServiceMetricLabel);
       });
     } else if (this.isApplicationSet(target.entity)) {
+      console.log("wants to fetch application metrics");
       return this.application.fetchApplicationMetrics(target, timeFilter).then(response => {
         target.showWarningCantShowAllResults = response.data.canLoadMore;
         return readItemMetrics(target, response, this.application.buildApplicationMetricLabel);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -34,7 +34,7 @@ export default class InstanaDatasource extends AbstractDatasource {
     this.application = new InstanaApplicationDataSource(instanceSettings, backendSrv, templateSrv, $q);
     this.website = new InstanaWebsiteDataSource(instanceSettings, backendSrv, templateSrv, $q);
     this.service = new InstanaServiceDataSource(instanceSettings, backendSrv, templateSrv, $q);
-    this.endpoint = new InstanaEndpointDataSource(instanceSettings, backendSrv, templateSrv, $q, this.service);
+    this.endpoint = new InstanaEndpointDataSource(instanceSettings, backendSrv, templateSrv, $q);
     this.availableGranularities = [];
     this.availableRollups = [];
   }
@@ -292,21 +292,26 @@ export default class InstanaDatasource extends AbstractDatasource {
   }
 
   getEndpointMetrics(target, timeFilter: TimeFilter) {
-    return this.endpoint.fetchEndpointMetrics(target, timeFilter).then(response => {
-      return readItemMetrics(target, response, this.endpoint.buildEndpointMetricLabel);
-    });
+
   }
 
   getApplicationServiceEndpointMetrics(target, timeFilter: TimeFilter) {
     if (target.entity && !target.service && !target.endpoint) {
+      console.log("application");
       return this.application.fetchApplicationMetrics(target, timeFilter).then(response => {
         target.showWarningCantShowAllResults = response.data.canLoadMore;
         return readItemMetrics(target, response, this.application.buildApplicationMetricLabel);
       });
     } else if (target.entity && target.service && !target.endpoint) {
-      console.log("applicaton and service");
+      console.log("application and service");
+      return this.service.fetchServiceMetrics(target, timeFilter).then(response => {
+        return readItemMetrics(target, response, this.service.buildServiceMetricLabel);
+      });
     } else if (target.entity && target.service && target.endpoint) {
       console.log("application and service and endpoint");
+      return  this.endpoint.fetchEndpointMetrics(target, timeFilter).then(response => {
+        return readItemMetrics(target, response, this.endpoint.buildEndpointMetricLabel);
+      });
     }
   }
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -296,21 +296,20 @@ export default class InstanaDatasource extends AbstractDatasource {
   }
 
   getApplicationServiceEndpointMetrics(target, timeFilter: TimeFilter) {
-    if (this.isApplicationSet(target.entity) && !this.isServiceSet(target.service) && !this.isEndpointSet(target.endpoint)) {
-      console.log("application");
-      return this.application.fetchApplicationMetrics(target, timeFilter).then(response => {
-        target.showWarningCantShowAllResults = response.data.canLoadMore;
-        return readItemMetrics(target, response, this.application.buildApplicationMetricLabel);
+    if (this.isEndpointSet(target.endpoint)) {
+      //endpoint metrics
+      return  this.endpoint.fetchEndpointMetrics(target, timeFilter).then(response => {
+        return readItemMetrics(target, response, this.endpoint.buildEndpointMetricLabel);
       });
-    } else if (this.isApplicationSet(target.entity) && this.isServiceSet(target.service) && !this.isEndpointSet(target.endpoint)) {
-      console.log("application and service");
+    } else if (this.isServiceSet(target.service)) {
+      //service metrics
       return this.service.fetchServiceMetrics(target, timeFilter).then(response => {
         return readItemMetrics(target, response, this.service.buildServiceMetricLabel);
       });
-    } else if (this.isApplicationSet(target.entity) && this.isServiceSet(target.service) && this.isEndpointSet(target.endpoint)) {
-      console.log("application and service and endpoint");
-      return  this.endpoint.fetchEndpointMetrics(target, timeFilter).then(response => {
-        return readItemMetrics(target, response, this.endpoint.buildEndpointMetricLabel);
+    } else if (this.isApplicationSet(target.entity)) {
+      return this.application.fetchApplicationMetrics(target, timeFilter).then(response => {
+        target.showWarningCantShowAllResults = response.data.canLoadMore;
+        return readItemMetrics(target, response, this.application.buildApplicationMetricLabel);
       });
     }
   }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -79,12 +79,6 @@ export default class InstanaDatasource extends AbstractDatasource {
             return this.getAnalyzeApplicationMetrics(target, timeFilter);
           } else if (target.metricCategory === this.APPLICATION_SERVICE_ENDPOINT_METRICS) {
              return this.getApplicationServiceEndpointMetrics(target, timeFilter);
-          } else if (target.metricCategory === this.APPLICATION_METRICS) {
-            return this.getApplicationMetrics(target, timeFilter);
-          } else if (target.metricCategory === this.SERVICE_METRICS) {
-            return this.getServiceMetrics(target, timeFilter);
-          } else if (target.metricCategory === this.ENDPOINT_METRICS) {
-            return this.getEndpointMetrics(target, timeFilter);
           }
         }
       })
@@ -276,23 +270,6 @@ export default class InstanaDatasource extends AbstractDatasource {
       target.showWarningCantShowAllResults = response.data.canLoadMore;
       return readItemMetrics(target, response, this.application.buildAnalyzeApplicationLabel);
     });
-  }
-
-  getApplicationMetrics(target, timeFilter: TimeFilter) {
-    return this.application.fetchApplicationMetrics(target, timeFilter).then(response => {
-      target.showWarningCantShowAllResults = response.data.canLoadMore;
-      return readItemMetrics(target, response, this.application.buildApplicationMetricLabel);
-    });
-  }
-
-  getServiceMetrics(target, timeFilter: TimeFilter) {
-    return this.service.fetchServiceMetrics(target, timeFilter).then(response => {
-      return readItemMetrics(target, response, this.service.buildServiceMetricLabel);
-    });
-  }
-
-  getEndpointMetrics(target, timeFilter: TimeFilter) {
-
   }
 
   getApplicationServiceEndpointMetrics(target, timeFilter: TimeFilter) {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -77,6 +77,8 @@ export default class InstanaDatasource extends AbstractDatasource {
             return this.getAnalyzeWebsiteMetrics(target, timeFilter);
           } else if (target.metricCategory === this.ANALYZE_APPLICATION_METRICS) {
             return this.getAnalyzeApplicationMetrics(target, timeFilter);
+          } else if (target.metricCategory === this.APPLICATION_SERVICE_ENDPOINT_METRICS) {
+             return this.getApplicationServiceEndpointMetrics(target, timeFilter);
           } else if (target.metricCategory === this.APPLICATION_METRICS) {
             return this.getApplicationMetrics(target, timeFilter);
           } else if (target.metricCategory === this.SERVICE_METRICS) {
@@ -293,6 +295,19 @@ export default class InstanaDatasource extends AbstractDatasource {
     return this.endpoint.fetchEndpointMetrics(target, timeFilter).then(response => {
       return readItemMetrics(target, response, this.endpoint.buildEndpointMetricLabel);
     });
+  }
+
+  getApplicationServiceEndpointMetrics(target, timeFilter: TimeFilter) {
+    if (target.entity && !target.service && !target.endpoint) {
+      return this.application.fetchApplicationMetrics(target, timeFilter).then(response => {
+        target.showWarningCantShowAllResults = response.data.canLoadMore;
+        return readItemMetrics(target, response, this.application.buildApplicationMetricLabel);
+      });
+    } else if (target.entity && target.service && !target.endpoint) {
+      console.log("applicaton and service");
+    } else if (target.entity && target.service && target.endpoint) {
+      console.log("application and service and endpoint");
+    }
   }
 
   annotationQuery(options) {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -297,18 +297,15 @@ export default class InstanaDatasource extends AbstractDatasource {
 
   getApplicationServiceEndpointMetrics(target, timeFilter: TimeFilter) {
     if (target.entity && !target.service && !target.endpoint) {
-      console.log("application");
       return this.application.fetchApplicationMetrics(target, timeFilter).then(response => {
         target.showWarningCantShowAllResults = response.data.canLoadMore;
         return readItemMetrics(target, response, this.application.buildApplicationMetricLabel);
       });
     } else if (target.entity && target.service && !target.endpoint) {
-      console.log("application and service");
       return this.service.fetchServiceMetrics(target, timeFilter).then(response => {
         return readItemMetrics(target, response, this.service.buildServiceMetricLabel);
       });
     } else if (target.entity && target.service && target.endpoint) {
-      console.log("application and service and endpoint");
       return  this.endpoint.fetchEndpointMetrics(target, timeFilter).then(response => {
         return readItemMetrics(target, response, this.endpoint.buildEndpointMetricLabel);
       });

--- a/src/datasource_abstract.ts
+++ b/src/datasource_abstract.ts
@@ -23,10 +23,10 @@ export default class AbstractDatasource {
   CUSTOM_METRICS = '1';
   ANALYZE_APPLICATION_METRICS = '2';
   ANALYZE_WEBSITE_METRICS = '3';
-  APPLICATION_METRICS = '4';
-  SERVICE_METRICS = '5';
-  ENDPOINT_METRICS = '6';
-  APPLICATION_SERVICE_ENDPOINT_METRICS = '4';
+  APPLICATION_SERVICE_ENDPOINT_METRICS = '4'; // replaces previous
+  // APPLICATION_METRICS = '4';
+  // SERVICE_METRICS = '5';
+  // ENDPOINT_METRICS = '6';
 
   /** @ngInject */
   constructor(instanceSettings, public backendSrv, public templateSrv, public $q) {

--- a/src/datasource_abstract.ts
+++ b/src/datasource_abstract.ts
@@ -25,6 +25,7 @@ export default class AbstractDatasource {
   APPLICATION_METRICS = '4';
   SERVICE_METRICS = '5';
   ENDPOINT_METRICS = '6';
+  APPLICATION_SERVICE_ENDPOINT_METRICS = '4';
 
   /** @ngInject */
   constructor(instanceSettings, public backendSrv, public templateSrv, public $q) {

--- a/src/datasource_abstract.ts
+++ b/src/datasource_abstract.ts
@@ -15,6 +15,7 @@ export default class AbstractDatasource {
 
   simpleCache: Cache<Array<Selectable>>;
 
+  PAGINATION_LIMIT = 50;
   CACHE_MAX_AGE = 60000;
   SEPARATOR = '|';
 

--- a/src/datasource_abstract.ts
+++ b/src/datasource_abstract.ts
@@ -15,7 +15,7 @@ export default class AbstractDatasource {
 
   simpleCache: Cache<Array<Selectable>>;
 
-  PAGINATION_LIMIT = 50;
+  PAGINATION_LIMIT = 15; // pagesize=200 => 3000 results in dropdown (~30sec.)
   CACHE_MAX_AGE = 60000;
   SEPARATOR = '|';
 

--- a/src/datasource_application.ts
+++ b/src/datasource_application.ts
@@ -37,7 +37,7 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
     let page = 1;
     let pageSize = 200;
 
-    applications = this.paginateApplications([], windowSize, timeFilter.to, page, pageSize).then(response => {
+    applications = this.paginateApplications([], windowSize, timeFilter.to, page, pageSize, this.PAGINATION_LIMIT).then(response => {
       let allResults = _.flattenDeep(_.map(response, (pageSet, index) => {
         return pageSet.items;
       }));
@@ -54,7 +54,11 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
     return applications;
   }
 
-  paginateApplications(results, windowSize: number, to: number, page: number, pageSize: number) {
+  paginateApplications(results, windowSize: number, to: number, page: number, pageSize: number, pageLimit: number) {
+    if (page > pageLimit) {
+      return results;
+    }
+
     var queryParameters = "windowSize=" + windowSize
       + "&to=" + to
       + "&page=" + page
@@ -64,7 +68,7 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
       results.push(response.data);
       if (page * pageSize < response.data.totalHits) {
         page++;
-        return this.paginateApplications(results, windowSize, to, page, pageSize);
+        return this.paginateApplications(results, windowSize, to, page, pageSize, pageLimit);
       } else {
         return results;
       }

--- a/src/datasource_endpoint.ts
+++ b/src/datasource_endpoint.ts
@@ -147,8 +147,13 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
       metrics: [metric]
     };
 
-    data['applicationId'] = target.entity.key;
-    data['serviceId'] = target.service.key;
+    if (target.entity && target.entity.key && target.entity.key !== "ALL_SERVICES") { //see migration.ts why "ALL_SERVICES"
+      data['applicationId'] = target.entity.key;
+    }
+
+    if (target.service && target.service.key) {
+      data['serviceId'] = target.service.key;
+    }
 
     return this.postRequest('/api/application-monitoring/metrics/endpoints?fillTimeSeries=true', data);
   }

--- a/src/datasource_endpoint.ts
+++ b/src/datasource_endpoint.ts
@@ -23,7 +23,7 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
 
   getEndpointsOfService(target, timeFilter: TimeFilter) {
     let applicationId = "";
-    if (target.entity && target.entity.key !== "ALL_SERVICES") { //see migration.ts why "ALL SERVICES"
+    if (target.entity && target.entity.key) {
       applicationId = target.entity.key;
     }
 
@@ -120,7 +120,7 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
 
   fetchEndpointMetrics(target, timeFilter: TimeFilter) {
     // avoid invalid calls
-    if (!target || !target.metric || !target.entity || !target.service || !target.endpoint) {
+    if (!target || !target.metric) {
       return this.$q.resolve({data: {items: []}});
     }
 
@@ -147,7 +147,7 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
       metrics: [metric]
     };
 
-    if (target.entity && target.entity.key && target.entity.key !== "ALL_SERVICES") { //see migration.ts why "ALL_SERVICES"
+    if (target.entity && target.entity.key) { //see migration.ts why "ALL_SERVICES"
       data['applicationId'] = target.entity.key;
     }
 

--- a/src/datasource_endpoint.ts
+++ b/src/datasource_endpoint.ts
@@ -23,7 +23,7 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
 
   getEndpointsOfService(target, timeFilter: TimeFilter) {
     let applicationId = "";
-    if (target.entity) {
+    if (target.entity && target.entity.key !== "ALL_SERVICES") { //see migration.ts why "ALL SERVICES"
       applicationId = target.entity.key;
     }
 

--- a/src/datasource_endpoint.ts
+++ b/src/datasource_endpoint.ts
@@ -43,7 +43,8 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
     let pageSize = 200;
 
 
-    endpoints = this.paginateEndpoints([], applicationId, serviceId, windowSize, timeFilter.to, page, pageSize).then(response => {
+    endpoints = this.paginateEndpoints([], applicationId, serviceId, windowSize, timeFilter.to, page, pageSize, this.PAGINATION_LIMIT)
+      .then(response => {
       let allResults = _.flattenDeep(_.map(response, (pageSet, index) => {
         return pageSet.items;
       }));
@@ -60,7 +61,11 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
     return endpoints;
   }
 
-  paginateEndpoints(results, applicationId, serviceId, windowSize: number, to: number, page: number, pageSize: number) {
+  paginateEndpoints(results, applicationId, serviceId, windowSize: number, to: number, page: number, pageSize: number, pageLimit: number) {
+    if (page > pageLimit) {
+      return results;
+    }
+
     var queryParameters = "windowSize=" + windowSize
       + "&to=" + to
       + "&page=" + page
@@ -76,7 +81,7 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
       results.push(response.data);
       if (page * pageSize < response.data.totalHits) {
         page++;
-        return this.paginateEndpoints(results, applicationId, serviceId, windowSize, to, page, pageSize);
+        return this.paginateEndpoints(results, applicationId, serviceId, windowSize, to, page, pageSize, pageLimit);
       } else {
         return results;
       }

--- a/src/datasource_endpoint.ts
+++ b/src/datasource_endpoint.ts
@@ -12,8 +12,8 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
   serviceDataSource: InstanaServiceDataSource;
   maximumNumberOfUsefulDataPoints = 80;
 
-  // duplicate to QueryCtrl.ALL_ENDPOINTS
-  ALL_ENDPOINTS = '-- No Endpoint Filter --';
+  // duplicate to QueryCtrl.NO_ENDPOINT_FILTER
+  NO_ENDPOINT_FILTER = '-- No Endpoint Filter --';
 
   /** @ngInject */
   constructor(instanceSettings, backendSrv, templateSrv, $q) {
@@ -83,41 +83,6 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
     });
   }
 
-  getApplicationsUsingEndpoint(target, timeFilter: TimeFilter) {
-    const windowSize = this.getWindowSize(timeFilter);
-
-    const metric = {
-      metric: "calls",
-      aggregation: "SUM"
-    };
-
-    const data = {
-      timeFrame: {
-        to: timeFilter.to,
-        windowSize: windowSize
-      },
-      metrics: [metric],
-      endpointId: target.entity.key
-    };
-
-    let page = 1;
-    let pageSize = 200;
-    let pagination = {
-      page: page,
-      pageSize: pageSize
-    };
-
-    data['pagination'] = pagination;
-
-    return this.postRequest('/api/application-monitoring/metrics/applications', data).then(response => {
-      let filteredData = _.filter(response.data.items, item => item.metrics['calls.sum'][0][0] > 0);
-      return filteredData.map(entry => ({
-        'key': entry.application.id,
-        'label': entry.application.label
-      }));
-    });
-  }
-
   fetchEndpointMetrics(target, timeFilter: TimeFilter) {
     // avoid invalid calls
     if (!target || !target.metric) {
@@ -162,8 +127,9 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
     if (target.labelFormat) {
       let label = target.labelFormat;
       label = _.replace(label, '$label', item.endpoint.label);
-      label = _.replace(label, 'endpoint', target.entity.label);
-      label = _.replace(label, '$application', target.selectedApplication.label);
+      label = _.replace(label, '$endpoint', target.endpoint.label);
+      label = _.replace(label, '$service', target.service.label);
+      label = _.replace(label, '$application', target.entity.label);
       label = _.replace(label, '$metric', target.metric.label);
       label = _.replace(label, '$key', key);
       label = _.replace(label, '$index', index + 1);
@@ -171,14 +137,14 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
       return label;
     }
 
-    if (target.entity.label === this.ALL_ENDPOINTS) {
+    if (target.endpoint.label === this.NO_ENDPOINT_FILTER) {
       return target.timeShift ? item.endpoint.label + ' - ' + key + " - " + target.timeShift : item.endpoint.label + ' - ' + key;
     }
 
     return target.timeShift && target.timeShiftIsValid ?
-      item.endpoint.label + ' (' + target.entity.label + ')' + ' - ' + key + " - " + target.timeShift
+      item.endpoint.label + ' (' + target.endpoint.label + ')' + ' - ' + key + " - " + target.timeShift
       :
-      item.endpoint.label + ' (' + target.entity.label + ')' + ' - ' + key;
+      item.endpoint.label + ' (' + target.endpoint.label + ')' + ' - ' + key;
   }
 
 }

--- a/src/datasource_endpoint.ts
+++ b/src/datasource_endpoint.ts
@@ -150,9 +150,6 @@ export default class InstanaEndpointDataSource extends AbstractDatasource {
     data['applicationId'] = target.entity.key;
     data['serviceId'] = target.service.key;
 
-    console.log(target.endpoint);
-    console.log(data);
-
     return this.postRequest('/api/application-monitoring/metrics/endpoints?fillTimeSeries=true', data);
   }
 

--- a/src/datasource_service.ts
+++ b/src/datasource_service.ts
@@ -23,7 +23,7 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
 
   getServicesOfApplication(target, timeFilter: TimeFilter) {
     let applicationId = "";
-    if (target.entity && target.entity.key !== "ALL_SERVICES") {
+    if (target.entity && target.entity.key) {
       applicationId = target.entity.key;
     }
 
@@ -139,7 +139,7 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
       metrics: [metric]
     };
 
-    if (target.entity && target.entity.key && target.entity.key !== "ALL_SERVICES") { //see migration.ts why "ALL_SERVICES"
+    if (target.entity && target.entity.key) { //see migration.ts why "ALL_SERVICES"
       data['applicationId'] = target.entity.key;
     }
 

--- a/src/datasource_service.ts
+++ b/src/datasource_service.ts
@@ -22,9 +22,9 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
   }
 
   getServicesOfApplication(target, timeFilter: TimeFilter) {
-    let applicationId = target.entity.key;
-    if (!applicationId) {
-      return null;
+    let applicationId = "";
+    if (target.entity) {
+      applicationId = target.entity.key;
     }
 
     const key = this.getTimeKey(timeFilter) + applicationId;

--- a/src/datasource_service.ts
+++ b/src/datasource_service.ts
@@ -35,7 +35,7 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
     let page = 1;
     let pageSize = 200;
 
-    services = this.paginateServices([], applicationId, windowSize, timeFilter.to, page, pageSize).then(response => {
+    services = this.paginateServices([], applicationId, windowSize, timeFilter.to, page, pageSize, this.PAGINATION_LIMIT).then(response => {
       let allResults = _.flattenDeep(_.map(response, (pageSet, index) => {
         return pageSet.items;
       }));
@@ -52,7 +52,11 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
     return services;
   }
 
-  paginateServices(results, applicationId, windowSize: number, to: number, page: number, pageSize: number) {
+  paginateServices(results, applicationId, windowSize: number, to: number, page: number, pageSize: number, pageLimit: number) {
+    if (page > pageLimit) {
+      return results;
+    }
+
     var queryParameters = "windowSize=" + windowSize
       + "&to=" + to
       + "&page=" + page
@@ -67,7 +71,7 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
       results.push(response.data);
       if (page * pageSize < response.data.totalHits) {
         page++;
-        return this.paginateServices(applicationId, results, windowSize, to, page, pageSize);
+        return this.paginateServices(applicationId, results, windowSize, to, page, pageSize, pageLimit);
       } else {
         return results;
       }

--- a/src/datasource_service.ts
+++ b/src/datasource_service.ts
@@ -23,7 +23,7 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
 
   getServicesOfApplication(target, timeFilter: TimeFilter) {
     let applicationId = "";
-    if (target.entity) {
+    if (target.entity && target.entity.key !== "ALL_SERVICES") {
       applicationId = target.entity.key;
     }
 
@@ -113,7 +113,7 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
 
   fetchServiceMetrics(target, timeFilter: TimeFilter) {
     // avoid invalid calls
-    if (!target || !target.metric || !target.entity || !target.service) {
+    if (!target || !target.metric) {
       return this.$q.resolve({data: {items: []}});
     }
 
@@ -139,8 +139,13 @@ export default class InstanaServiceDataSource extends AbstractDatasource {
       metrics: [metric]
     };
 
-    data['applicationId'] = target.entity.key;
-    data['serviceId'] = target.service.key;
+    if (target.entity && target.entity.key && target.entity.key !== "ALL_SERVICES") { //see migration.ts why "ALL_SERVICES"
+      data['applicationId'] = target.entity.key;
+    }
+
+    if (target.service && target.service.key) {
+      data['serviceId'] = target.service.key;
+    }
 
     return this.postRequest('/api/application-monitoring/metrics/services?fillTimeSeries=true', data);
   }

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -1,5 +1,6 @@
 // can be removed once mixpanel shows no old plugins around
 export default function (target) {
+  console.log(target);
   // 1.3.1 towards 2.0.0
   if (target.entityType && typeof target.entityType === 'string') {
     target.entityType = {key: target.entityType, label: target.entityType};
@@ -32,6 +33,7 @@ export default function (target) {
     }
   }
 
+  //2.4.3 towards 2.5.0
   if (target.metricCategory === '6') {
     //old service metric view
     target.metricCategory = '4';

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -22,10 +22,11 @@ export default function (target) {
     }
   }
 
-  //2.4.3 towards 2.5.0
+  //2.4.4 towards 2.5.0
   if (target.metricCategory === '5') {
     //old service metric view
     target.metricCategory = '4';
+    target.service = {}; //because target.endpoint does not exist yet.
     target.service.key = target.entity.key;
     target.service.label = target.entity.label;
     if (target.selectedApplication && target.selectedApplication.key) {
@@ -39,7 +40,7 @@ export default function (target) {
     }
   }
 
-  //2.4.3 towards 2.5.0
+  //2.4.4 towards 2.5.0
   if (target.metricCategory === '6') {
     //old endpoint metric view
     target.metricCategory = '4';

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -39,6 +39,11 @@ export default function (target) {
         target.entity.key = null;
       }
     }
+
+    console.log("new service:");
+    console.log(target.service);
+    console.log("old application entity");
+    console.log(target.entity);
   }
 
   //2.4.3 towards 2.5.0

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -27,8 +27,12 @@ export default function (target) {
   if (target.metricCategory === '5') {
     //old service metric view
     target.metricCategory = '4';
+    console.log("old service entity:");
+    console.log(target.entity);
     target.service = target.entity;
     if (target.selectedApplication) {
+      console.log("old selected application:");
+      console.log(target.selectedApplication);
       target.entity = target.selectedApplication;
     }
   }

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -43,10 +43,8 @@ export default function (target) {
   if (target.metricCategory === '6') {
     //old endpoint metric view
     target.metricCategory = '4';
+    target.endpoint = {}; //because target.endpoint does not exist yet.
     target.endpoint.key = target.entity.key;
-    target.endpoint.label = target.entity.label;
-    target.service.key = null;
-    target.service.label = "-- No Service Filter --";
     if (target.selectedApplication && target.selectedApplication.key) {
       target.entity.key = target.selectedApplication.key;
       target.entity.label = target.selectedApplication.label;

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -29,12 +29,14 @@ export default function (target) {
     target.metricCategory = '4';
     console.log("old service entity:");
     console.log(target.entity);
-    target.service = target.entity;
+    target.service.key = target.entity.key;
+    target.service.label = target.entity.label;
     if (target.selectedApplication) {
       console.log("old selected application:");
       console.log(target.selectedApplication);
       if (target.selectedApplication.key) {
-        target.entity = target.selectedApplication;
+        target.entity.key = target.selectedApplication.key;
+        target.entity.label = target.selectedApplication.label;
       } else {
         target.entity.key = null;
       }

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -35,7 +35,7 @@ export default function (target) {
 
   //2.4.3 towards 2.5.0
   if (target.metricCategory === '6') {
-    //old service metric view
+    //old endpoint metric view
     target.metricCategory = '4';
     target.endpoint = target.entity;
     if (target.selectedApplication) {

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -43,9 +43,15 @@ export default function (target) {
   if (target.metricCategory === '6') {
     //old endpoint metric view
     target.metricCategory = '4';
-    target.endpoint = target.entity;
-    if (target.selectedApplication) {
-      target.entity = target.selectedApplication;
+    target.endpoint.key = target.entity.key;
+    target.endpoint.label = target.entity.label;
+    target.service.key = null;
+    target.service.label = "-- No Service Filter --";
+    if (target.selectedApplication && target.selectedApplication.key) {
+      target.entity.key = target.selectedApplication.key;
+      target.entity.label = target.selectedApplication.label;
+    } else {
+      target.entity.key = "ALL_SERVICES";
     }
   }
 }

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -1,6 +1,5 @@
 // can be removed once mixpanel shows no old plugins around
 export default function (target) {
-  console.log(target);
   // 1.3.1 towards 2.0.0
   if (target.entityType && typeof target.entityType === 'string') {
     target.entityType = {key: target.entityType, label: target.entityType};

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -27,25 +27,16 @@ export default function (target) {
   if (target.metricCategory === '5') {
     //old service metric view
     target.metricCategory = '4';
-    console.log("old service entity:");
-    console.log(target.entity);
     target.service.key = target.entity.key;
     target.service.label = target.entity.label;
-    if (target.selectedApplication) {
-      console.log("old selected application:");
-      console.log(target.selectedApplication);
-      if (target.selectedApplication.key) {
-        target.entity.key = target.selectedApplication.key;
-        target.entity.label = target.selectedApplication.label;
-      } else {
-        target.entity.key = null;
-      }
+    if (target.selectedApplication && target.selectedApplication.key) {
+      target.entity.key = target.selectedApplication.key;
+      target.entity.label = target.selectedApplication.label;
+    } else {
+      // this will be recognized by query control and later on be changed to the "All Services"
+      // application that is always present with proper id.
+      target.entity.key = "ALL_SERVICES";
     }
-
-    console.log("new service:");
-    console.log(target.service);
-    console.log("old application entity");
-    console.log(target.entity);
   }
 
   //2.4.3 towards 2.5.0

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -33,7 +33,11 @@ export default function (target) {
     if (target.selectedApplication) {
       console.log("old selected application:");
       console.log(target.selectedApplication);
-      target.entity = target.selectedApplication;
+      if (target.selectedApplication.key) {
+        target.entity = target.selectedApplication;
+      } else {
+        target.entity.key = null;
+      }
     }
   }
 

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -35,7 +35,8 @@ export default function (target) {
     } else {
       // this will be recognized by query control and later on be changed to the "All Services"
       // application that is always present with proper id.
-      target.entity.key = "ALL_SERVICES";
+      target.entity.key = null;
+      target.entity.label = "Test";
     }
   }
 
@@ -49,7 +50,8 @@ export default function (target) {
       target.entity.key = target.selectedApplication.key;
       target.entity.label = target.selectedApplication.label;
     } else {
-      target.entity.key = "ALL_SERVICES";
+      target.entity.key = null;
+      target.entity.label = "Test";
     }
   }
 }

--- a/src/migration.ts
+++ b/src/migration.ts
@@ -21,4 +21,23 @@ export default function (target) {
       target.timeInterval = {key: target.timeInterval.rollup, label: target.timeInterval.label};
     }
   }
+
+  //2.4.3 towards 2.5.0
+  if (target.metricCategory === '5') {
+    //old service metric view
+    target.metricCategory = '4';
+    target.service = target.entity;
+    if (target.selectedApplication) {
+      target.entity = target.selectedApplication;
+    }
+  }
+
+  if (target.metricCategory === '6') {
+    //old service metric view
+    target.metricCategory = '4';
+    target.endpoint = target.entity;
+    if (target.selectedApplication) {
+      target.entity = target.selectedApplication;
+    }
+  }
 }

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -15,7 +15,7 @@
                 ng-change="ctrl.onMetricCategorySelect()">
           <option value="0" selected>Infrastructure built-in metrics</option>
           <option value="1">Infrastructure custom metrics</option>
-          <option value="4">Application/Service/Metrics Metrics</option>
+          <option value="4">Application/Service/Endpoint metrics</option>
           <option value="2">Analyze application calls</option>
           <option value="3">Analyze websites</option>
         </select>
@@ -455,7 +455,6 @@
                 ng-model="ctrl.target.service"
                 ng-change="ctrl.onServiceSelect()"
                 ng-options="f as f.label for f in ctrl.uniqueServices track by f.key">
-          <option value="" disabled selected>{{ctrl.serviceSelectionText}}</option>
         </select>
         <label class="gf-form-label query-keyword pointer width-13"
                for="select-endpoint-{{ctrl.target.refId}}">
@@ -470,7 +469,6 @@
                 ng-model="ctrl.target.endpoint"
                 ng-change="ctrl.onChange()"
                 ng-options="f as f.label for f in ctrl.uniqueEndpoints track by f.key">
-          <option value="" disabled selected>{{ctrl.endpointSelectionText}}</option>
         </select>
       </div>
     </script>

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -65,25 +65,7 @@
       <div ng-include src="'application_service_endpoint.html'"/>
       <div ng-include src="'metric.html'"/>
       <div ng-include src="'advanced_settings.html'"/>
-      <div ng-include src="'application_legend.html'"/>
-      <div ng-include src="'timeshift.html'"/>
-      <div ng-include src="'aggregate_graphs.html'"/>
-    </div>
-
-    <div ng-show="ctrl.target.metricCategory === '5'">
-      <div ng-include src="'serviceEndpoint.html'"/>
-      <div ng-include src="'metric.html'"/>
-      <div ng-include src="'advanced_settings.html'"/>
-      <div ng-include src="'service_legend.html'"/>
-      <div ng-include src="'timeshift.html'"/>
-      <div ng-include src="'aggregate_graphs.html'"/>
-    </div>
-
-    <div ng-show="ctrl.target.metricCategory === '6'">
-      <div ng-include src="'serviceEndpoint.html'"/>
-      <div ng-include src="'metric.html'"/>
-      <div ng-include src="'advanced_settings.html'"/>
-      <div ng-include src="'endpoint_legend.html'"/>
+      <div ng-include src="'application_service_endpoint_legend.html'"/>
       <div ng-include src="'timeshift.html'"/>
       <div ng-include src="'aggregate_graphs.html'"/>
     </div>
@@ -310,16 +292,17 @@
       </div>
     </script>
 
-    <script type="text/ng-template" id="endpoint_legend.html">
+    <script type="text/ng-template" id="application_service_endpoint_legend.html">
       <div class="gf-form" ng-show="ctrl.target.showAdvancedSettings">
         <label class="gf-form-label query-keyword width-13 pointer">
           Legend format
           <info-popover position="top center" mode="right-normal">
-            Default: $label ($endpoint) - $key
+            Default: $label ($application) - $key
             <ul>
               <li>$label - entity label</li>
+              <li>$application - application label</li>
+              <li>$service - service label</li>
               <li>$endpoint - endpoint label</li>
-              <li>$application - application context (if selected)</li>
               <li>$timeShift - corresponding timeShift</li>
               <li>$metric - displayed metric</li>
               <li>$key - metric key with aggregation and rollup</li>
@@ -327,40 +310,12 @@
             </ul>
           </info-popover>
         </label>
-        <input id="in-endpoint-legend-{{ctrl.target.refId}}"
+        <input id="in-application-service-endpoint-legend-{{ctrl.target.refId}}"
                class="gf-form-input width-22"
                type="text"
                ng-model="ctrl.target.labelFormat"
                ng-model-options='{ debounce: 500 }'
-               placeholder="$label ($endpoint) - $key"
-               ng-change="ctrl.onChange()"
-               spellcheck='false'/>
-      </div>
-    </script>
-
-    <script type="text/ng-template" id="service_legend.html">
-      <div class="gf-form" ng-show="ctrl.target.showAdvancedSettings">
-        <label class="gf-form-label query-keyword width-13 pointer">
-          Legend format
-          <info-popover position="top center" mode="right-normal">
-            Default: $label ($service) - $key
-            <ul>
-              <li>$label - entity label</li>
-              <li>$service - endpoint label</li>
-              <li>$application - application context (if selected)</li>
-              <li>$timeShift - corresponding timeShift</li>
-              <li>$metric - displayed metric</li>
-              <li>$key - metric key with aggregation and rollup</li>
-              <li>$index - index in the list</li>
-            </ul>
-          </info-popover>
-        </label>
-        <input id="in-service-legend-{{ctrl.target.refId}}"
-               class="gf-form-input width-22"
-               type="text"
-               ng-model="ctrl.target.labelFormat"
-               ng-model-options='{ debounce: 500 }'
-               placeholder="$label ($service) - $key"
+               placeholder="$label ($application) - $key"
                ng-change="ctrl.onChange()"
                spellcheck='false'/>
       </div>
@@ -612,57 +567,6 @@
         </label>
         <gf-form-switch ng-disabled="!ctrl.target.aggregateGraphs" id="in-hide-graphs-{{ctrl.target.refId}}"
                         checked="ctrl.target.hideOriginalGraphs" on-change="ctrl.onChange()"/>
-      </div>
-    </script>
-
-    <script type="text/ng-template" id="serviceEndpoint.html">
-      <div class="gf-form">
-        <label class="gf-form-label query-keyword pointer width-13"
-               for="in-serviceEndpoint-namefilter-{{ctrl.target.refId}}">
-          Filter {{ctrl.serviceEndpointTitle}}
-          <info-popover position="top center" mode="right-normal">
-            <p>Filters the list of {{ctrl.serviceEndpointTitle}}s to only show the ones that contain the given
-              input.</p>
-          </info-popover>
-        </label>
-        <input id="in-serviceEndpoint-namefilter-{{ctrl.target.refId}}"
-               class="gf-form-input"
-               type="text"
-               ng-model='ctrl.target.serviceNamefilter'
-               ng-model-options='{ debounce: 500 }'
-               ng-change="ctrl.onNamefilterChanges()"
-               placeholder="Please Specify"
-               spellcheck='false'>
-        <label class="gf-form-label query-keyword width-13 pointer"
-               for="in-service-{{ctrl.target.refId}}">
-          {{ctrl.serviceEndpointTitle}}
-          <info-popover position="top center" mode="right-normal">
-            <p>Select your {{ctrl.serviceEndpointTitle}}.</p>
-          </info-popover>
-        </label>
-        <select id="in-service-{{ctrl.target.refId}}"
-                class="gf-form-input ng-valid ng-not-empty ng-touched"
-                ng-model="ctrl.target.entity"
-                ng-change="ctrl.onServiceEndpointSelected()"
-                ng-options="f as f.label for f in ctrl.target.availableServicesEndpoints track by f.key">
-          <option value="" disabled selected>{{ctrl.serviceEndpointSelectionText}}</option>
-        </select>
-        <label class="gf-form-label query-keyword width-13 pointer"
-               for="in-application-{{ctrl.target.refId}}"
-               ng-show="ctrl.supportsApplicationPerspective()">
-          Application Context
-          <info-popover position="top center" mode="right-normal">
-            <p>This will filter your selected {{ctrl.serviceEndpointTitle}} and show only metrics related to this
-              application perspective.</p>
-          </info-popover>
-        </label>
-        <select ng-show="ctrl.supportsApplicationPerspective()"
-                id="in-application-{{ctrl.target.refId}}"
-                class="gf-form-input ng-valid ng-not-empty ng-touched"
-                ng-model="ctrl.target.selectedApplication"
-                ng-change="ctrl.onChange()"
-                ng-options="f as f.label for f in ctrl.target.relatedApplications track by f.key">
-        </select>
       </div>
     </script>
   </div>

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -439,7 +439,7 @@
         <select id="select-application-{{ctrl.target.refId}}"
                 class="gf-form-input ng-pristine ng-valid ng-not-empty ng-touched"
                 ng-model="ctrl.target.entity"
-                ng-change="ctrl.loadServices()"
+                ng-change="ctrl.onApplicationSelect()"
                 ng-options="f as f.label for f in ctrl.uniqueEntities track by f.key">
         </select>
         <label class="gf-form-label query-keyword pointer width-13"
@@ -453,7 +453,7 @@
                 ng-disabled="!ctrl.target.entity.key"
                 class="gf-form-input ng-pristine ng-valid ng-not-empty ng-touched"
                 ng-model="ctrl.target.service"
-                ng-change="ctrl.loadEndpoints()"
+                ng-change="ctrl.onServiceSelect()"
                 ng-options="f as f.label for f in ctrl.uniqueServices track by f.key">
           <option value="" disabled selected>{{ctrl.serviceSelectionText}}</option>
         </select>

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -15,9 +15,7 @@
                 ng-change="ctrl.onMetricCategorySelect()">
           <option value="0" selected>Infrastructure built-in metrics</option>
           <option value="1">Infrastructure custom metrics</option>
-          <option value="4">Application Metrics</option>
-          <option value="5">Service Metrics</option>
-          <option value="6">Endpoint Metrics</option>
+          <option value="4">Application/Service/Metrics Metrics</option>
           <option value="2">Analyze application calls</option>
           <option value="3">Analyze websites</option>
         </select>
@@ -64,7 +62,7 @@
     </div>
 
     <div ng-show="ctrl.target.metricCategory === '4'">
-      <div ng-include src="'website_application.html'"/>
+      <div ng-include src="'application_service_endpoint.html'"/>
       <div ng-include src="'metric.html'"/>
       <div ng-include src="'advanced_settings.html'"/>
       <div ng-include src="'application_legend.html'"/>
@@ -426,6 +424,54 @@
                ng-change="ctrl.onChange()"
                placeholder="Please Specify"
                spellcheck='false'/>
+      </div>
+    </script>
+
+    <script type="text/ng-template" id="application_service_endpoint.html">
+      <div class="gf-form">
+        <label class="gf-form-label query-keyword pointer width-13"
+               for="select-application-{{ctrl.target.refId}}">
+          Application
+          <info-popover position="top center" mode="right-normal">
+            <p>Select your application.</p>
+          </info-popover>
+        </label>
+        <select id="select-application-{{ctrl.target.refId}}"
+                class="gf-form-input ng-pristine ng-valid ng-not-empty ng-touched"
+                ng-model="ctrl.target.entity"
+                ng-change="ctrl.loadServices()"
+                ng-options="f as f.label for f in ctrl.uniqueEntities track by f.key">
+        </select>
+        <label class="gf-form-label query-keyword pointer width-13"
+               for="select-service-{{ctrl.target.refId}}">
+           Service
+           <info-popover position="top center" mode="right-normal">
+             <p>Select your service.</p>
+           </info-popover>
+        </label>
+        <select id="select-service-{{ctrl.target.refId}}"
+                ng-disabled="!ctrl.target.entity.key"
+                class="gf-form-input ng-pristine ng-valid ng-not-empty ng-touched"
+                ng-model="ctrl.target.service"
+                ng-change="ctrl.loadEndpoints()"
+                ng-options="f as f.label for f in ctrl.uniqueServices track by f.key">
+          <option value="" disabled selected>{{ctrl.serviceSelectionText}}</option>
+        </select>
+        <label class="gf-form-label query-keyword pointer width-13"
+               for="select-endpoint-{{ctrl.target.refId}}">
+          Endpoint
+          <info-popover position="top center" mode="right-normal">
+            <p>Select your endpoint.</p>
+          </info-popover>
+        </label>
+        <select id="select-endpoint-{{ctrl.target.refId}}"
+                ng-disabled="!ctrl.target.service.key"
+                class="gf-form-input ng-pristine ng-valid ng-not-empty ng-touched"
+                ng-model="ctrl.target.endpoint"
+                ng-change="ctrl.onChange()"
+                ng-options="f as f.label for f in ctrl.uniqueEndpoints track by f.key">
+          <option value="" disabled selected>{{ctrl.endpointSelectionText}}</option>
+        </select>
       </div>
     </script>
 

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -177,7 +177,7 @@
         <label class="gf-form-label query-keyword pointer" for="in-timeInterval-{{ctrl.target.refId}}">
           Rollup
           <info-popover position="top center" mode="right-normal">
-            <p>Select the Rollup value</p>
+            <p>Select the rollup value.</p>
           </info-popover>
         </label>
         <div class="gf-form-select-wrapper min-width-8 gf-form-select-wrapper--has-help-icon">
@@ -309,7 +309,7 @@
                for="in-group-{{ctrl.target.refId}}">
           Group by
           <info-popover position="top center" mode="right-normal">
-            <p>Group by tag</p>
+            <p>Group by tag.</p>
           </info-popover>
         </label>
         <div ng-show="ctrl.isAnalyzeCategory()"
@@ -348,7 +348,7 @@
                 ng-change="ctrl.onApplicationSelect()"
                 ng-options="f as f.label for f in ctrl.uniqueEntities track by f.key">
         </select>
-        <label class="gf-form-label query-keyword pointer width-13"
+        <label class="gf-form-label query-keyword pointer"
                for="select-service-{{ctrl.target.refId}}">
            Service
            <info-popover position="top center" mode="right-normal">
@@ -361,7 +361,7 @@
                 ng-change="ctrl.onServiceSelect()"
                 ng-options="f as f.label for f in ctrl.uniqueServices track by f.key">
         </select>
-        <label class="gf-form-label query-keyword pointer width-13"
+        <label class="gf-form-label query-keyword pointer"
                for="select-endpoint-{{ctrl.target.refId}}">
           Endpoint
           <info-popover position="top center" mode="right-normal">
@@ -384,7 +384,7 @@
                  for="in-filter-name-{{ctrl.target.refId}}-{{$index}}">
             {{$index+1}}. Filter
             <info-popover position="top center" class="ng-invalid" mode="right-normal">
-              <p>Filter by tag</p>
+              <p>Filter by tag.</p>
             </info-popover>
           </label>
           <div class="gf-form-select-wrapper width-14 gf-form-select-wrapper--has-help-icon">
@@ -441,7 +441,7 @@
         <label class="gf-form-label width-13 pointer" for="in-{{ctrl.target.analyzeType}}-{{ctrl.target.refId}}">
           Add filter
           <info-popover position="top center" mode="right-normal">
-            <p>Add an additional tag filter</p>
+            <p>Add an additional tag filter.</p>
           </info-popover>
         </label>
         <button class="gf-form-input btn btn-inverse width-3" ng-click="ctrl.addFilter()">
@@ -452,7 +452,7 @@
                ng-hide="!ctrl.target.showWarningCantShowAllResults">
           ⚠️ Can't show all results
           <info-popover position="top center" mode="right-normal">
-            <p>Add Filter to narrow down the data</p>
+            <p>Add Filter to narrow down the data.</p>
           </info-popover>
         </label>
       </div>

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -163,6 +163,9 @@
         <label class="gf-form-label query-keyword pointer" for="in-metric-{{ctrl.target.refId}}"
                ng-show="ctrl.canShowAggregation()">
           Aggregation
+          <info-popover position="top center" mode="right-normal">
+            <p>Select a metric aggretion.</p>
+          </info-popover>
         </label>
         <div class="gf-form-select-wrapper min-width-8"
              ng-show="ctrl.canShowAggregation()">

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -244,32 +244,30 @@
     </script>
 
     <script type="text/ng-template" id="application_service_endpoint_legend.html">
-      <div class="gf-form" ng-show="ctrl.target.showAdvancedSettings">
-        <label class="gf-form-label query-keyword width-13 pointer">
-          Legend format
-          <info-popover position="top center" mode="right-normal">
-            Default: $label ($application) - $key
-            <ul>
-              <li>$label - entity label</li>
-              <li>$application - application label</li>
-              <li>$service - service label</li>
-              <li>$endpoint - endpoint label</li>
-              <li>$timeShift - corresponding timeShift</li>
-              <li>$metric - displayed metric</li>
-              <li>$key - metric key with aggregation and rollup</li>
-              <li>$index - index in the list</li>
-            </ul>
-          </info-popover>
-        </label>
-        <input id="in-application-service-endpoint-legend-{{ctrl.target.refId}}"
-               class="gf-form-input width-22"
-               type="text"
-               ng-model="ctrl.target.labelFormat"
-               ng-model-options='{ debounce: 500 }'
-               placeholder="$label ($application) - $key"
-               ng-change="ctrl.onChange()"
-               spellcheck='false'/>
-      </div>
+      <label class="gf-form-label query-keyword width-13 pointer">
+        Legend format
+        <info-popover position="top center" mode="right-normal">
+          Default: $label ($application) - $key
+          <ul>
+            <li>$label - entity label</li>
+            <li>$application - application label</li>
+            <li>$service - service label</li>
+            <li>$endpoint - endpoint label</li>
+            <li>$timeShift - corresponding timeShift</li>
+            <li>$metric - displayed metric</li>
+            <li>$key - metric key with aggregation and rollup</li>
+            <li>$index - index in the list</li>
+          </ul>
+        </info-popover>
+      </label>
+      <input id="in-application-service-endpoint-legend-{{ctrl.target.refId}}"
+             class="gf-form-input full-width"
+             type="text"
+             ng-model="ctrl.target.labelFormat"
+             ng-model-options='{ debounce: 500 }'
+             placeholder="$label ($application) - $key"
+             ng-change="ctrl.onChange()"
+             spellcheck='false'/>
     </script>
 
     <script type="text/ng-template" id="website_application.html">
@@ -473,7 +471,7 @@
       <div class="gf-form" ng-show="ctrl.target.showAdvancedSettings">
         <div class="gf-form full-width" ng-show="ctrl.isInfrastructure()" ng-include src="'legend.html'"/>
         <div class="gf-form full-width" ng-show="ctrl.isAnalyzeApplication()" ng-include src="'application_legend.html'"/>
-        <div class="gf-form full-width" ng-show="ctrl.isApplicationMetric()" ng-include src="'application_service_endpoint_legend.html'"/>
+        <div class="gf-form full-width" ng-show="ctrl.isApplicationServiceEndpointMetric()" ng-include src="'application_service_endpoint_legend.html'"/>
         <div class="gf-form full-width" ng-show="ctrl.isAnalyzeWebsite()" ng-include src="'website_legend.html'"/>
         <div class="gf-form full-width" ng-include src="'timeshift.html'"/>
       </div>

--- a/src/partials/query.editor.html
+++ b/src/partials/query.editor.html
@@ -450,7 +450,6 @@
            </info-popover>
         </label>
         <select id="select-service-{{ctrl.target.refId}}"
-                ng-disabled="!ctrl.target.entity.key"
                 class="gf-form-input ng-pristine ng-valid ng-not-empty ng-touched"
                 ng-model="ctrl.target.service"
                 ng-change="ctrl.onServiceSelect()"
@@ -464,7 +463,6 @@
           </info-popover>
         </label>
         <select id="select-endpoint-{{ctrl.target.refId}}"
-                ng-disabled="!ctrl.target.service.key"
                 class="gf-form-input ng-pristine ng-valid ng-not-empty ng-touched"
                 ng-model="ctrl.target.endpoint"
                 ng-change="ctrl.onChange()"

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -696,6 +696,7 @@ export class InstanaQueryCtrl extends QueryCtrl {
     this.resetServices();
     this.resetEndpoints();
     this.loadServices();
+    this.loadEndpoints();
     this.panelCtrl.refresh();
   }
 

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -236,11 +236,6 @@ export class InstanaQueryCtrl extends QueryCtrl {
           this.uniqueEntities.unshift({key: null, label: this.NO_APPLICATION_FILTER});
         }
 
-        //migrate old application
-        if (this.target.entity && this.target.entity.key === "ALL_SERVICES") { //see migration.ts
-          this.target.entity = this.uniqueEntities[1];
-        }
-
         // replace removed application
         if (this.target && this.target.entity && !_.find(applications, ['key', this.target.entity.key])) {
           this.target.entity = this.uniqueEntities[0];

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -32,8 +32,6 @@ export class InstanaQueryCtrl extends QueryCtrl {
 
   snapshots: Array<string>;
   entitySelectionText: string;
-  //serviceSelectionText: string;
-  //endpointSelectionText: string;
   metricSelectionText: string;
   serviceEndpointSelectionText: string;
   previousMetricCategory: string;
@@ -152,7 +150,6 @@ export class InstanaQueryCtrl extends QueryCtrl {
       }
     });
   }
-
 
   isInfrastructure() {
     return this.target.metricCategory === this.BUILT_IN_METRICS || this.target.metricCategory === this.CUSTOM_METRICS;
@@ -277,7 +274,6 @@ export class InstanaQueryCtrl extends QueryCtrl {
             this.target.service = this.uniqueServices[0];
           }
         }
-        //this.serviceSelectionText = this.buildSelectionPlaceholderText(this.uniqueServices);
       }
     );
 
@@ -300,7 +296,6 @@ export class InstanaQueryCtrl extends QueryCtrl {
             this.target.endpoint = this.uniqueEndpoints[0];
           }
         }
-        //this.endpointSelectionText = this.buildSelectionPlaceholderText(this.uniqueEndpoints);
       }
     );
 
@@ -351,7 +346,6 @@ export class InstanaQueryCtrl extends QueryCtrl {
           this.websiteApplicationLabel = "Website";
           this.onWebsiteChanges(false, true);
         } else if (this.isApplicationServiceEndpointMetric()) {
-          this.websiteApplicationLabel = "Application";
           this.onApplicationChanges(false, false);
           this.loadServices();
           this.loadEndpoints();
@@ -633,23 +627,6 @@ export class InstanaQueryCtrl extends QueryCtrl {
   }
 
   onChange() {
-    this.panelCtrl.refresh();
-  }
-
-  onServiceEndpointSelected() {
-    if (this.isServiceMetric()) {
-      this.datasource.service.getApplicationsUsingService(this.target, this.timeFilter).then(applications => {
-        this.target.relatedApplications = applications;
-        this.target.relatedApplications.unshift({key: null, label: "No Application Selected"});
-        this.target.selectedApplication = this.target.relatedApplications[0];
-      });
-    } else {
-      this.datasource.endpoint.getApplicationsUsingEndpoint(this.target, this.timeFilter).then(applications => {
-        this.target.relatedApplications = applications;
-        this.target.relatedApplications.unshift({key: null, label: "No Application Selected"});
-        this.target.selectedApplication = this.target.relatedApplications[0];
-      });
-    }
     this.panelCtrl.refresh();
   }
 

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -32,8 +32,8 @@ export class InstanaQueryCtrl extends QueryCtrl {
 
   snapshots: Array<string>;
   entitySelectionText: string;
-  serviceSelectionText: string;
-  endpointSelectionText: string;
+  //serviceSelectionText: string;
+  //endpointSelectionText: string;
   metricSelectionText: string;
   serviceEndpointSelectionText: string;
   previousMetricCategory: string;
@@ -43,9 +43,9 @@ export class InstanaQueryCtrl extends QueryCtrl {
   customFilters = [];
 
   EMPTY_DROPDOWN_TEXT = ' - ';
-  ALL_APPLICATIONS = '-- No Application Filter --';
-  ALL_SERVICES = '-- No Service Filter --';
-  ALL_ENDPOINTS = '-- No Endpoint Filter --';
+  NO_APPLICATION_FILTER = '-- No Application Filter --';
+  NO_SERVICE_FILTER = '-- No Service Filter --';
+  NO_ENDPOINT_FILTER = '-- No Endpoint Filter --';
 
   OPERATOR_STRING = 'STRING';
   OPERATOR_NUMBER = 'NUMBER';
@@ -151,7 +151,6 @@ export class InstanaQueryCtrl extends QueryCtrl {
         this.target.metric = _.find(this.availableMetrics, m => m.key === this.target.metric.key);
       }
     });
-    console.log(this.target);
   }
 
 
@@ -232,7 +231,7 @@ export class InstanaQueryCtrl extends QueryCtrl {
         this.uniqueEntities = _.orderBy(applications, [application => application.label.toLowerCase()], ['asc']);
         // if all is not existing, we insert it on top
         if (!_.find(this.uniqueEntities, {'key': null})) {
-          this.uniqueEntities.unshift({key: null, label: this.ALL_APPLICATIONS});
+          this.uniqueEntities.unshift({key: null, label: this.NO_APPLICATION_FILTER});
         }
         // replace removed application
         if (this.target && this.target.entity && !_.find(applications, ['key', this.target.entity.key])) {
@@ -271,7 +270,13 @@ export class InstanaQueryCtrl extends QueryCtrl {
     this.datasource.service.getServicesOfApplication(this.target, this.timeFilter).then(
       services => {
         this.uniqueServices = _.orderBy(services, [service => service.label.toLowerCase()], ['asc']);
-        this.serviceSelectionText = this.buildSelectionPlaceholderText(this.uniqueServices);
+        if (!_.find(this.uniqueServices, {'key': null})) {
+          this.uniqueServices.unshift({key: null, label: this.NO_SERVICE_FILTER});
+          if (!this.target.service) {
+            this.target.service = this.uniqueServices[0];
+          }
+        }
+        //this.serviceSelectionText = this.buildSelectionPlaceholderText(this.uniqueServices);
       }
     );
 
@@ -289,7 +294,13 @@ export class InstanaQueryCtrl extends QueryCtrl {
       endpoints => {
         this.uniqueEndpoints = _.orderBy(endpoints, [endpoint => endpoint.label.toLowerCase()], ['asc']);
         console.log(this.uniqueEndpoints);
-        this.endpointSelectionText = this.buildSelectionPlaceholderText(this.uniqueEndpoints);
+        if (!_.find(this.uniqueEndpoints, {'key': null})) {
+          this.uniqueEndpoints.unshift({key: null, label: this.NO_ENDPOINT_FILTER});
+          if (!this.target.endpoint) {
+            this.target.endpoint = this.uniqueEndpoints[0];
+          }
+        }
+        //this.endpointSelectionText = this.buildSelectionPlaceholderText(this.uniqueEndpoints);
       }
     );
 

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -131,11 +131,9 @@ export class InstanaQueryCtrl extends QueryCtrl {
         if (this.target.metric) {
           this.target.metric = _.find(this.availableMetrics, m => m.key === this.target.metric.key);
         }
-      }).then(() => {
-        this.loadServices();
-      }).then(() => {
-        this.loadEndpoints();
       });
+      this.loadServices();
+      this.loadEndpoints();
     }
   }
 
@@ -352,17 +350,11 @@ export class InstanaQueryCtrl extends QueryCtrl {
         } else if (this.isAnalyzeWebsite()) {
           this.websiteApplicationLabel = "Website";
           this.onWebsiteChanges(false, true);
-        } else if (this.isApplicationMetric()) {
+        } else if (this.isApplicationServiceEndpointMetric()) {
           this.websiteApplicationLabel = "Application";
           this.onApplicationChanges(false, false);
-        } else if (this.isServiceMetric()) {
-          this.serviceEndpointTitle = "Service";
-          this.onFilterChange(false);
-          this.onServiceChanges(false);
-        } else if (this.isEndpointMetric()) {
-          this.serviceEndpointTitle = "Endpoint";
-          this.onFilterChange(false);
-          this.onEndpointChanges(false);
+          this.loadServices();
+          this.loadEndpoints();
         }
       }
     }

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -131,9 +131,11 @@ export class InstanaQueryCtrl extends QueryCtrl {
         if (this.target.metric) {
           this.target.metric = _.find(this.availableMetrics, m => m.key === this.target.metric.key);
         }
+      }).then(() => {
+        this.loadServices();
+      }).then(() => {
+        this.loadEndpoints();
       });
-      this.loadServices();
-      this.loadEndpoints();
     }
   }
 
@@ -233,6 +235,12 @@ export class InstanaQueryCtrl extends QueryCtrl {
         if (!_.find(this.uniqueEntities, {'key': null})) {
           this.uniqueEntities.unshift({key: null, label: this.NO_APPLICATION_FILTER});
         }
+
+        //migrate old application
+        if (this.target.entity && this.target.entity.key === "ALL_SERVICES") { //see migration.ts
+          this.target.entity = this.uniqueEntities[1];
+        }
+
         // replace removed application
         if (this.target && this.target.entity && !_.find(applications, ['key', this.target.entity.key])) {
           this.target.entity = this.uniqueEntities[0];

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -293,7 +293,6 @@ export class InstanaQueryCtrl extends QueryCtrl {
     this.datasource.endpoint.getEndpointsOfService(this.target, this.timeFilter).then(
       endpoints => {
         this.uniqueEndpoints = _.orderBy(endpoints, [endpoint => endpoint.label.toLowerCase()], ['asc']);
-        console.log(this.uniqueEndpoints);
         if (!_.find(this.uniqueEndpoints, {'key': null})) {
           this.uniqueEndpoints.unshift({key: null, label: this.NO_ENDPOINT_FILTER});
           if (!this.target.endpoint) {

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -151,6 +151,7 @@ export class InstanaQueryCtrl extends QueryCtrl {
         this.target.metric = _.find(this.availableMetrics, m => m.key === this.target.metric.key);
       }
     });
+    console.log(this.target);
   }
 
 
@@ -267,20 +268,10 @@ export class InstanaQueryCtrl extends QueryCtrl {
   }
 
   onServiceChanges(refresh: boolean) {
-    this.datasource.service.getServices(this.target, this.timeFilter).then(
+    this.datasource.service.getServicesOfApplication(this.target, this.timeFilter).then(
       services => {
         this.uniqueServices = _.orderBy(services, [service => service.label.toLowerCase()], ['asc']);
-        // if all is not existing, we insert it on top
-        //if (!_.find(this.uniqueServices, {'key': null})) {
-        //  this.uniqueServices.unshift({key: null, label: this.ALL_SERVICES});
-        //}
         this.serviceSelectionText = this.buildSelectionPlaceholderText(this.uniqueServices);
-        // replace removed service
-        //if (this.target && this.target.service && !_.find(services, ['key', this.target.service.key])) {
-        //  this.target.service = this.uniqueServices[0];
-        //} else if (this.target && !this.target.service && services) {
-        //  this.target.service = this.uniqueServices[0];
-        //}
       }
     );
 
@@ -294,20 +285,11 @@ export class InstanaQueryCtrl extends QueryCtrl {
   }
 
   onEndpointChanges(refresh: boolean) {
-    this.datasource.endpoint.getEndpoints(this.target, this.timeFilter).then(
+    this.datasource.endpoint.getEndpointsOfService(this.target, this.timeFilter).then(
       endpoints => {
         this.uniqueEndpoints = _.orderBy(endpoints, [endpoint => endpoint.label.toLowerCase()], ['asc']);
-        // if all is not existing, we insert it on top
-        //if (!_.find(this.uniqueEndpoints, {'key': null})) {
-        //  this.uniqueEndpoints.unshift({key: null, label: this.ALL_ENDPOINTS});
-        //}
+        console.log(this.uniqueEndpoints);
         this.endpointSelectionText = this.buildSelectionPlaceholderText(this.uniqueEndpoints);
-        // replace removed endpoint
-        //if (this.target && this.target.endpoint && !_.find(endpoints, ['key', this.target.endpoint.key])) {
-        //  this.target.endpoint = this.uniqueEndpoints[0];
-        //} else if (this.target && !this.target.entity && endpoints) {
-        //  this.target.endpoint = this.uniqueEndpoints[0];
-        //}
       }
     );
 
@@ -566,6 +548,8 @@ export class InstanaQueryCtrl extends QueryCtrl {
     this.target.showAllMetrics = false;
     this.target.canShowAllMetrics = false;
     this.serviceEndpointSelectionText = this.EMPTY_DROPDOWN_TEXT;
+    this.resetServices();
+    this.resetEndpoints();
   }
 
   resetMetricSelection() {
@@ -577,6 +561,16 @@ export class InstanaQueryCtrl extends QueryCtrl {
     this.target.showAllMetrics = false;
     this.target.labelFormat = null;
     this.metricSelectionText = this.EMPTY_DROPDOWN_TEXT;
+  }
+
+  resetServices() {
+    this.target.service = null;
+    this.uniqueServices = [];
+  }
+
+  resetEndpoints() {
+    this.target.endpoint = null;
+    this.uniqueEndpoints = [];
   }
 
   adjustEntitySelectionPlaceholder() {
@@ -681,11 +675,14 @@ export class InstanaQueryCtrl extends QueryCtrl {
   }
 
   onApplicationSelect() {
+    this.resetServices();
+    this.resetEndpoints();
     this.loadServices();
     this.panelCtrl.refresh();
   }
 
   onServiceSelect() {
+    this.resetEndpoints();
     this.loadEndpoints();
     this.panelCtrl.refresh();
   }

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -176,18 +176,6 @@ export class InstanaQueryCtrl extends QueryCtrl {
     return this.target.metricCategory === this.APPLICATION_SERVICE_ENDPOINT_METRICS;
   }
 
-  isApplicationMetric() {
-    return this.target.metricCategory === this.APPLICATION_METRICS;
-  }
-
-  isServiceMetric() {
-    return this.target.metricCategory === this.SERVICE_METRICS;
-  }
-
-  isEndpointMetric() {
-    return this.target.metricCategory === this.ENDPOINT_METRICS;
-  }
-
   onWebsiteChanges(refresh, isAnalyze: boolean) {
     // select a meaningful default group
     if (this.target && !this.target.entityType) {

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -680,6 +680,16 @@ export class InstanaQueryCtrl extends QueryCtrl {
     }
   }
 
+  onApplicationSelect() {
+    this.loadServices();
+    this.panelCtrl.refresh();
+  }
+
+  onServiceSelect() {
+    this.loadEndpoints();
+    this.panelCtrl.refresh();
+  }
+
   toggleAdvancedSettings() {
     this.target.showAdvancedSettings = !this.target.showAdvancedSettings;
   }


### PR DESCRIPTION
This PR removes the old application service and endpoint category. This is done in order to avoid the "flow" of work from selecting e.g. endpoints and then finding corresponding applications but instead reverse it to first select an application, then a service, and then finally an endpoint.