### PR TITLE
Implement entity destination tag for analyze calls

### DIFF
--- a/src/datasource_application.ts
+++ b/src/datasource_application.ts
@@ -84,7 +84,7 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
       tagsResponse.data.map(entry => ({
         'key': entry.name,
         'type': entry.type,
-        'canApplyToDestination': entry.canApplyToDestination
+        'tagEntity': entry.canApplyToDestination ? 'DESTINATION' : 'NOT_APPLICABLE'
       }))
     );
     this.simpleCache.put('applicationTags', applicationTags);
@@ -133,14 +133,14 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
         name: 'application.name',
         operator: 'EQUALS',
         value: target.entity.label,
-        entity: "DESTINATION"
+        entity: 'DESTINATION'
       });
     }
 
     _.forEach(target.filters, filter => {
       if (filter.isValid) {
         let tagFilter = createTagFilter(filter);
-        tagFilter['groupbyTagEntity'] = filter.tag.canApplyToDestination ? "DESTINATION" : "NOT_APPLICABLE";
+        tagFilter['groupbyTagEntity'] = filter.tag.tagEntity;
         tagFilters.push(tagFilter);
       }
     });
@@ -161,7 +161,7 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
       groupbyTag: target.group.key
     };
 
-    group['groupbyTagEntity'] = target.group.canApplyToDestination ? "DESTINATION" : "NOT_APPLICABLE";
+    group['groupbyTagEntity'] = target.group.tagEntity;
 
     if (target.group.type === "KEY_VALUE_PAIR" && target.groupbyTagSecondLevelKey) {
       group['groupbyTagSecondLevelKey'] = target.groupbyTagSecondLevelKey;

--- a/src/datasource_application.ts
+++ b/src/datasource_application.ts
@@ -74,7 +74,7 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
     });
   }
 
-  getApplicastionTags() {
+  getApplicationTags() {
     let applicationTags = this.simpleCache.get('applicationTags');
     if (applicationTags) {
       return applicationTags;
@@ -83,7 +83,8 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
     applicationTags = this.doRequest('/api/application-monitoring/catalog/tags').then(tagsResponse =>
       tagsResponse.data.map(entry => ({
         'key': entry.name,
-        'type': entry.type
+        'type': entry.type,
+        'canApplyToDestination': entry.canApplyToDestination
       }))
     );
     this.simpleCache.put('applicationTags', applicationTags);
@@ -139,7 +140,7 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
     _.forEach(target.filters, filter => {
       if (filter.isValid) {
         let tagFilter = createTagFilter(filter);
-        tagFilter['entity'] = "DESTINATION";
+        tagFilter['groupbyTagEntity'] = filter.tag.canApplyToDestination ? "DESTINATION" : "NOT_APPLICABLE";
         tagFilters.push(tagFilter);
       }
     });
@@ -157,9 +158,11 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
     }
 
     const group = {
-      groupbyTag: target.group.key,
-      groupbyTagEntity: "DESTINATION"
+      groupbyTag: target.group.key
     };
+
+    group['groupbyTagEntity'] = target.group.canApplyToDestination ? "DESTINATION" : "NOT_APPLICABLE";
+
     if (target.group.type === "KEY_VALUE_PAIR" && target.groupbyTagSecondLevelKey) {
       group['groupbyTagSecondLevelKey'] = target.groupbyTagSecondLevelKey;
     }

--- a/src/datasource_application.ts
+++ b/src/datasource_application.ts
@@ -131,13 +131,16 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
       tagFilters.push({
         name: 'application.name',
         operator: 'EQUALS',
-        value: target.entity.label
+        value: target.entity.label,
+        entity: "DESTINATION"
       });
     }
 
     _.forEach(target.filters, filter => {
       if (filter.isValid) {
-        tagFilters.push(createTagFilter(filter));
+        let tagFilter = createTagFilter(filter);
+        tagFilter['entity'] = "DESTINATION";
+        tagFilters.push(tagFilter);
       }
     });
 
@@ -154,7 +157,8 @@ export default class InstanaApplicationDataSource extends AbstractDatasource {
     }
 
     const group = {
-      groupbyTag: target.group.key
+      groupbyTag: target.group.key,
+      groupbyTagEntity: "DESTINATION"
     };
     if (target.group.type === "KEY_VALUE_PAIR" && target.groupbyTagSecondLevelKey) {
       group['groupbyTagSecondLevelKey'] = target.groupbyTagSecondLevelKey;

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -238,7 +238,7 @@ export class InstanaQueryCtrl extends QueryCtrl {
     );
 
     if (isAnalyze) {
-      this.datasource.application.getApplicastionTags().then(
+      this.datasource.application.getApplicationTags().then(
         applicationTags => {
           this.uniqueTags =
             _.sortBy(

--- a/src/util/analyze_util.ts
+++ b/src/util/analyze_util.ts
@@ -35,5 +35,3 @@ export function readItemMetrics(target, response, getLabel) {
     });
   }));
 }
-
-


### PR DESCRIPTION
This PR is response to the ZD Ticket #10960. It fixes a bug that did not allow the grouping of analyze calls by application.name.