### PR TITLE
Adjust granularity levels to backend materialized view limits

### DIFF
--- a/specs/granularity_rollup_specs.ts
+++ b/specs/granularity_rollup_specs.ts
@@ -140,10 +140,6 @@ describe('Given a timeInterval', function () {
     it('should allow 10s, 1min, 5min, 10min, 1h analyze granularity', function () {
       const expected = [
         {
-          key: '10',
-          label: '10s'
-        },
-        {
           key: '60',
           label: '1min'
         },
@@ -282,14 +278,6 @@ describe('Given a timeInterval', function () {
     it('should allow 5min, 10min, 1h, 5h, 10h, 1d analyze granularity', function () {
       const expected = [
         {
-          key: '300',
-          label: '5min'
-        },
-        {
-          key: '600',
-          label: '10min'
-        },
-        {
           key: '3600',
           label: '1h'
         },
@@ -350,14 +338,6 @@ describe('Given a timeInterval', function () {
     };
     it('should allow 5min, 10min, 1h, 5h, 10h, 1d analyze granularity', function () {
       const expected = [
-        {
-          key: '300',
-          label: '5min'
-        },
-        {
-          key: '600',
-          label: '10min'
-        },
         {
           key: '3600',
           label: '1h'

--- a/specs/granularity_rollup_specs.ts
+++ b/specs/granularity_rollup_specs.ts
@@ -137,7 +137,7 @@ describe('Given a timeInterval', function () {
       to: Date.now(),
       windowSize: windowSize
     };
-    it('should allow 10s, 1min, 5min, 10min, 1h analyze granularity', function () {
+    it('should allow 1min, 5min, 10min, 1h analyze granularity', function () {
       const expected = [
         {
           key: '60',
@@ -275,7 +275,7 @@ describe('Given a timeInterval', function () {
       to: Date.now(),
       windowSize: windowSize
     };
-    it('should allow 5min, 10min, 1h, 5h, 10h, 1d analyze granularity', function () {
+    it('should allow 1h, 5h, 10h, 1d analyze granularity', function () {
       const expected = [
         {
           key: '3600',
@@ -336,7 +336,7 @@ describe('Given a timeInterval', function () {
       to: Date.now(),
       windowSize: windowSize
     };
-    it('should allow 5min, 10min, 1h, 5h, 10h, 1d analyze granularity', function () {
+    it('should allow 1h, 5h, 10h, 1d analyze granularity', function () {
       const expected = [
         {
           key: '3600',

--- a/src/util/rollup_granularity_util.ts
+++ b/src/util/rollup_granularity_util.ts
@@ -24,10 +24,19 @@ export function getDefaultChartGranularity(windowSize: number): Selectable {
 }
 
 export function getPossibleGranularities(windowSize: number, maxValues = MAX_DATAPOINTS_ANALYZE): Selectable[] {
-  const possibleGranularities = granularities.filter(
+  let possibleGranularities = granularities.filter(
     granularity => windowSize / 1000 / granularity.value <= maxValues &&
       granularity.value * 1000 <= windowSize
   );
+
+  // window sizes of this length and up have a granularity of at least 1h
+  if (windowSize > 48000001) {
+    possibleGranularities = possibleGranularities.filter(granularity => granularity.value >= 3600);
+  }
+
+  if (windowSize >= 1800000) {
+    possibleGranularities = possibleGranularities.filter(granularity => granularity.value >= 60);
+  }
 
   if (possibleGranularities.length > 0) {
     return possibleGranularities.map(granularity => ({


### PR DESCRIPTION
## WHY 
appdata-reader does not support smaller granularities anymore while using then new materialized views

## WHAT
Includes two changes:

* only allow selection of granularities below 1min when the time window is smaller than 30min
* only allow selection of granularities below 1h when the time window is smaller than 2d