### PR TITLE
add delta request

### DIFF
--- a/specs/add_datasource_specs.js
+++ b/specs/add_datasource_specs.js
@@ -34,12 +34,9 @@ describe('When adding the Instana datasource to Grafana', function() {
     installButton.click();
     await page.waitFor(1000); // don't ask
 
-    // Generate random datasource name to allow for multiple runs without refreshing Grafana.
-    let runId = randomString(6);
-    // await page.type('input[ng-model="ctrl.current.name"]', instanaUiBackendUrl + "-" + runId);
-    console.log(page.content().then(content => {
+    page.content().then(content => {
       return content
-    }));
+    });
     await page.type('input[id=in-url]', instanaUiBackendUrl);
     await page.type('input[ng-model="ctrl.current.jsonData.apiToken"]', instanaApiToken);
     const saveAndTestButton = await page.waitForXPath('//button[contains(text(),"Save & Test")]');

--- a/specs/aggregation_specs.ts
+++ b/specs/aggregation_specs.ts
@@ -3,31 +3,6 @@ import { aggregateTarget } from "../src/util/aggregation_util";
 
 describe('Given a dataset', function() {
   describe('with 3 entries', function() {
-    /*
-      [
-        {
-          datapoints: [
-            [0, 0],
-            [1, 100000000],
-            [2, 200000000]
-          ]
-        },
-        {
-          datapoints: [
-            [1, 0],
-            [2, 100000000],
-            [3, 200000000]
-          ]
-        },
-        {
-          datapoints: [
-            [2, 0],
-            [3, 100000000],
-            [4, 200000000]
-          ]
-        }
-      ]
-    */
     let data = generateTestData(3, 3);
 
     it('should aggregate correctly to SUM', function() {
@@ -80,7 +55,7 @@ describe('Given a dataset', function() {
 
     it('should aggregate correctly to MAX', function() {
       let target = buildTestTarget("MAX", "D");
-      
+
       const expected = {
         datapoints: [
           [2, 0],
@@ -97,6 +72,31 @@ describe('Given a dataset', function() {
 
 });
 
+/*
+  [
+    {
+      datapoints: [
+        [0, 0],
+        [1, 100000000],
+        [2, 200000000]
+      ]
+    },
+    {
+      datapoints: [
+        [1, 0],
+        [2, 100000000],
+        [3, 200000000]
+      ]
+    },
+    {
+      datapoints: [
+        [2, 0],
+        [3, 100000000],
+        [4, 200000000]
+      ]
+    }
+  ]
+*/
 function generateTestData(amountOfTimeseries, numberOfEntries) {
   var data = [];
   for (let i = 0; i < amountOfTimeseries; i++) {

--- a/specs/aggregation_specs.ts
+++ b/specs/aggregation_specs.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from './lib/common';
+import { aggregateTarget } from "../src/util/aggregation_util";
+
+describe('Given a dataset', function() {
+  describe('with 3 entries', function() {
+    /*
+      [
+        {
+          datapoints: [
+            [0, 0],
+            [1, 100000000],
+            [2, 200000000]
+          ]
+        },
+        {
+          datapoints: [
+            [1, 0],
+            [2, 100000000],
+            [3, 200000000]
+          ]
+        },
+        {
+          datapoints: [
+            [2, 0],
+            [3, 100000000],
+            [4, 200000000]
+          ]
+        }
+      ]
+    */
+    let data = generateTestData(3, 3);
+
+    it('should aggregate correctly to SUM', function() {
+      let target = buildTestTarget("SUM", "A");
+
+      const expected = {
+        datapoints: [
+          [3, 0],
+          [6, 100000000],
+          [9, 200000000]
+        ],
+        refId: target.refId,
+        target: target.aggregationFunction.label
+      };
+      let result = aggregateTarget(data, target);
+      expect(JSON.stringify(result)).to.equal(JSON.stringify(expected));
+    });
+
+    it('should aggregate correctly to MEAN', function() {
+      let target = buildTestTarget("MEAN", "B");
+
+      const expected = {
+        datapoints: [
+          [1, 0],
+          [2, 100000000],
+          [3, 200000000]
+        ],
+        refId: target.refId,
+        target: target.aggregationFunction.label
+      };
+      let result = aggregateTarget(data, target);
+      expect(JSON.stringify(result)).to.equal(JSON.stringify(expected));
+    });
+
+    it('should aggregate correctly to MIN', function() {
+      let target = buildTestTarget("MIN", "C");
+
+      const expected = {
+        datapoints: [
+          [0, 0],
+          [1, 100000000],
+          [2, 200000000]
+        ],
+        refId: target.refId,
+        target: target.aggregationFunction.label
+      };
+      let result = aggregateTarget(data, target);
+      expect(JSON.stringify(result)).to.equal(JSON.stringify(expected));
+    });
+
+    it('should aggregate correctly to MAX', function() {
+      let target = buildTestTarget("MAX", "D");
+      
+      const expected = {
+        datapoints: [
+          [2, 0],
+          [3, 100000000],
+          [4, 200000000]
+        ],
+        refId: target.refId,
+        target: target.aggregationFunction.label
+      };
+      let result = aggregateTarget(data, target);
+      expect(JSON.stringify(result)).to.equal(JSON.stringify(expected));
+    });
+  });
+
+});
+
+function generateTestData(amountOfTimeseries, numberOfEntries) {
+  var data = [];
+  for (let i = 0; i < amountOfTimeseries; i++) {
+    var timeseries = [];
+    for (let j = 0; j < numberOfEntries; j++) {
+      timeseries.push([j + i, j * 100000000]);
+    }
+    data.push({ datapoints: timeseries });
+  }
+  return data;
+}
+
+function buildTestTarget(aggregationFunctionLabel, refId) {
+  return {
+    showAllMetrics: true,
+    allMetrics: [
+      1, 2, 3, 4, 5
+    ],
+    aggregationFunction: {
+      label: aggregationFunctionLabel
+    },
+    refId: refId
+  };
+}

--- a/specs/datasource_specs.ts
+++ b/specs/datasource_specs.ts
@@ -1,4 +1,4 @@
-/* import {describe, beforeEach, it, sinon, expect, angularMocks} from './lib/common';
+import {describe, beforeEach, it, sinon, expect, angularMocks} from './lib/common';
 import InstanaDatasource from '../src/datasource';
 import TemplateSrvStub from './lib/template_srv_stub';
 import Q from 'q';
@@ -32,6 +32,7 @@ describe('Given an InstanaDatasource', function() {
 
     ctx.ds = new InstanaDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv, ctx.$q);
     ctx.ds.timeFilter = timeFilter;
+    ctx.ds.resultCache.put('version', 172, 3600000);
   });
 
   describe('When performing testDatasource', function() {
@@ -252,6 +253,8 @@ describe('Given an InstanaDatasource', function() {
       "intervalMs": 20000,
       "targets": [
         {
+          "refId": "A",
+          "metricCategory": '0',
           "entityQuery": "filler",
           "entityType": {
             "key": "process",
@@ -261,10 +264,12 @@ describe('Given an InstanaDatasource', function() {
             "key": "mem.virtual",
             "label": "Virtual",
           },
-          "refId": "A"
+          "snapshotCache": {},
+          "hide": false
         },
         {
           "refId": "B",
+          "metricCategory": '0',
           "entityQuery": "filler",
           "entityType": {
             "key": "process",
@@ -274,6 +279,7 @@ describe('Given an InstanaDatasource', function() {
             "key": "mem.virtual",
             "label": "Virtual",
           },
+          "snapshotCache": {},
           "hide": false
         }
       ],
@@ -343,15 +349,15 @@ describe('Given an InstanaDatasource', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1516451043603&to=1516472658604&time=1516472658604&size=100":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1516451044000&to=1516472659000&time=1516472659000&size=100":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1516472658604":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1516472659000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/snapshots/B?time=1516472658604":
+          case "/api/datasources/proxy/1/instana/api/snapshots/B?time=1516472659000":
             return ctx.$q.resolve(snapshotB);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1516451043603&to=1516472658604&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1516451044000&to=1516472659000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1516451043603&to=1516472658604&rollup=3600000&fillTimeSeries=true&snapshotId=B":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1516451044000&to=1516472659000&rollup=3600000&fillTimeSeries=true&snapshotId=B":
             return ctx.$q.resolve(metricsForB);
           default:
             throw new Error('Unexpected call URL: ' + options.url);
@@ -435,7 +441,9 @@ describe('Given an InstanaDatasource', function() {
       "intervalMs": 20000,
       "targets": [
         {
+          "refId": "A",
           "pluginId": "singlestat",
+          "metricCategory": '0',
           "entityQuery": "filler",
           "entityType": {
             "key": "process",
@@ -446,8 +454,7 @@ describe('Given an InstanaDatasource', function() {
             "label": "Virtual"
           },
           "aggregation" : "MEAN",
-          "snapshotCache": {},
-          "refId": "A"
+          "snapshotCache": {}
         }
       ],
       "format": "json",
@@ -495,11 +502,11 @@ describe('Given an InstanaDatasource', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248640603&to=1524421440603&time=1524421440603&size=100":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248641000&to=1524421441000&time=1524421441000&size=100":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421440603":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421441000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248640603&to=1524421440603&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248641000&to=1524421441000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
           default:
             throw new Error('Unexpected call URL: ' + options.url);
@@ -544,7 +551,9 @@ describe('Given an InstanaDatasource', function() {
       "intervalMs": 20000,
       "targets": [
         {
+          "refId": "A",
           "pluginId": "table",
+          "metricCategory": '0',
           "entityQuery": "filler",
           "entityType": {
             "key": "process",
@@ -555,8 +564,7 @@ describe('Given an InstanaDatasource', function() {
             "label": "Virtual"
           },
           "aggregation": "MEAN",
-          "snapshotCache": {},
-          "refId": "A"
+          "snapshotCache": {}
         }
       ],
       "format": "json",
@@ -604,11 +612,11 @@ describe('Given an InstanaDatasource', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248640603&to=1524421440603&time=1524421440603&size=100":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248641000&to=1524421441000&time=1524421441000&size=100":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421440603":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421441000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248640603&to=1524421440603&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248641000&to=1524421441000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
           default:
             throw new Error('Unexpected call URL: ' + options.url);
@@ -653,7 +661,9 @@ describe('Given an InstanaDatasource', function() {
       "intervalMs": 20000,
       "targets": [
         {
+          "refId": "A",
           "pluginId": "singlestat",
+          "metricCategory": '0',
           "entityQuery": "filler",
           "entityType": {
             "key": "process",
@@ -664,8 +674,7 @@ describe('Given an InstanaDatasource', function() {
             "label": "Virtual"
           },
           "aggregation": "SUM",
-          "snapshotCache": {},
-          "refId": "A"
+          "snapshotCache": {}
         }
       ],
       "format": "json",
@@ -713,11 +722,11 @@ describe('Given an InstanaDatasource', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248640603&to=1524421440603&time=1524421440603&size=100":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248641000&to=1524421441000&time=1524421441000&size=100":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421440603":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421441000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248640603&to=1524421440603&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248641000&to=1524421441000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
           default:
             throw new Error('Unexpected call URL: ' + options.url);
@@ -762,7 +771,9 @@ describe('Given an InstanaDatasource', function() {
       "intervalMs": 20000,
       "targets": [
         {
+          "refId": "A",
           "pluginId": "table",
+          "metricCategory": '0',
           "entityQuery": "filler",
           "entityType": {
             "key": "process",
@@ -773,8 +784,7 @@ describe('Given an InstanaDatasource', function() {
             "label": "Virtual"
           },
           "aggregation": "SUM",
-          "snapshotCache": {},
-          "refId": "A"
+          "snapshotCache": {}
         }
       ],
       "format": "json",
@@ -822,11 +832,11 @@ describe('Given an InstanaDatasource', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248640603&to=1524421440603&time=1524421440603&size=100":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248641000&to=1524421441000&time=1524421441000&size=100":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421440603":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421441000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248640603&to=1524421440603&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248641000&to=1524421441000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
           default:
             throw new Error('Unexpected call URL: ' + options.url);
@@ -924,6 +934,7 @@ describe('Given an InstanaDatasource with offline snapshots', function() {
     };
 
     ctx.ds = new InstanaDatasource(ctx.instanceSettings, ctx.backendSrv, ctx.templateSrv, ctx.$q);
+    ctx.ds.resultCache.put('version', 172, 3600000);
   });
 
   describe('When retrieving metrics for offline snapshots', function() {
@@ -947,6 +958,8 @@ describe('Given an InstanaDatasource with offline snapshots', function() {
       "intervalMs": 20000,
       "targets": [
         {
+          "refId": "A",
+          "metricCategory": '0',
           "entityQuery": "filler",
           "entityType": {
             "key": "process",
@@ -955,8 +968,7 @@ describe('Given an InstanaDatasource with offline snapshots', function() {
           "metric": {
             "key": "mem.virtual",
             "label": "Virtual",
-          },
-          "refId": "A"
+          }
         }
       ],
       "format": "json",
@@ -1004,11 +1016,11 @@ describe('Given an InstanaDatasource with offline snapshots', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248640603&to=1524421440603":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248641000&to=1524421441000":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?from=1524248640603&to=1524421440603":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?from=1524248641000&to=1524421441000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248640603&to=1524421440603&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248641000&to=1524421441000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
           default:
             throw new Error('Unexpected call URL: ' + options.url);
@@ -1032,5 +1044,24 @@ describe('Given an InstanaDatasource with offline snapshots', function() {
     });
 
   });
+
+  describe('When performing getVersion', function() {
+    const version = {
+      status: 200,
+      data: {
+        "imageTag":"2.172.9-0"
+      }
+    };
+    beforeEach(function() {
+      ctx.backendSrv.datasourceRequest = function(options) {
+        return ctx.$q.resolve(version);
+      };
+    });
+
+    it('should return a correct version.', function() {
+      return ctx.ds.getVersion().then(function(results) {
+        expect(results).to.equal(172);
+      });
+    });
+  });
 });
-*/

--- a/specs/datasource_specs.ts
+++ b/specs/datasource_specs.ts
@@ -349,15 +349,15 @@ describe('Given an InstanaDatasource', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1516451044000&to=1516472659000&time=1516472659000&size=100":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1516451043000&to=1516472658000&time=1516472658000&size=100":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1516472659000":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1516472658000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/snapshots/B?time=1516472659000":
+          case "/api/datasources/proxy/1/instana/api/snapshots/B?time=1516472658000":
             return ctx.$q.resolve(snapshotB);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1516451044000&to=1516472659000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1516451043000&to=1516472658000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1516451044000&to=1516472659000&rollup=3600000&fillTimeSeries=true&snapshotId=B":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1516451043000&to=1516472658000&rollup=3600000&fillTimeSeries=true&snapshotId=B":
             return ctx.$q.resolve(metricsForB);
           default:
             throw new Error('Unexpected call URL: ' + options.url);
@@ -502,11 +502,11 @@ describe('Given an InstanaDatasource', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248641000&to=1524421441000&time=1524421441000&size=100":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248640000&to=1524421440000&time=1524421440000&size=100":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421441000":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421440000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248641000&to=1524421441000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248640000&to=1524421440000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
           default:
             throw new Error('Unexpected call URL: ' + options.url);
@@ -612,11 +612,11 @@ describe('Given an InstanaDatasource', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248641000&to=1524421441000&time=1524421441000&size=100":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248640000&to=1524421440000&time=1524421440000&size=100":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421441000":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421440000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248641000&to=1524421441000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248640000&to=1524421440000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
           default:
             throw new Error('Unexpected call URL: ' + options.url);
@@ -722,11 +722,11 @@ describe('Given an InstanaDatasource', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248641000&to=1524421441000&time=1524421441000&size=100":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248640000&to=1524421440000&time=1524421440000&size=100":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421441000":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421440000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248641000&to=1524421441000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248640000&to=1524421440000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
           default:
             throw new Error('Unexpected call URL: ' + options.url);
@@ -832,11 +832,11 @@ describe('Given an InstanaDatasource', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248641000&to=1524421441000&time=1524421441000&size=100":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248640000&to=1524421440000&time=1524421440000&size=100":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421441000":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?time=1524421440000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248641000&to=1524421441000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248640000&to=1524421440000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
           default:
             throw new Error('Unexpected call URL: ' + options.url);
@@ -1016,11 +1016,11 @@ describe('Given an InstanaDatasource with offline snapshots', function() {
     beforeEach(function() {
       ctx.backendSrv.datasourceRequest = function(options) {
         switch (options.url) {
-          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248641000&to=1524421441000":
+          case "/api/datasources/proxy/1/instana/api/snapshots/context?q=filler%20AND%20entity.pluginId%3Aprocess&from=1524248640000&to=1524421440000":
             return ctx.$q.resolve(contexts);
-          case "/api/datasources/proxy/1/instana/api/snapshots/A?from=1524248641000&to=1524421441000":
+          case "/api/datasources/proxy/1/instana/api/snapshots/A?from=1524248640000&to=1524421440000":
             return ctx.$q.resolve(snapshotA);
-          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248641000&to=1524421441000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
+          case "/api/datasources/proxy/1/instana/api/metrics?metric=mem.virtual&from=1524248640000&to=1524421440000&rollup=3600000&fillTimeSeries=true&snapshotId=A":
             return ctx.$q.resolve(metricsForA);
           default:
             throw new Error('Unexpected call URL: ' + options.url);

--- a/specs/delta_specs.ts
+++ b/specs/delta_specs.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from './lib/common';
+import { appendData, generateStableHash, isOverlapping } from "../src/util/delta_util";
+import TimeFilter from '../src/types/time_filter';
+
+describe('Given a delta', function() {
+  describe('with two overlapping timeFilter', function() {
+    let preTimeFilter: TimeFilter = {
+      from: 10300000,
+      to: 10600000,
+      windowSize: 300000
+    };
+
+    it('should find after overlap', function() {
+      let newTimeFilter: TimeFilter = {
+        from: 10500000,
+        to: 10700000,
+        windowSize: 200000
+      };
+
+      let result = isOverlapping(newTimeFilter, preTimeFilter);
+      expect(result).to.equal(true);
+    });
+
+    it('should not find before overlap', function() {
+      let newTimeFilter: TimeFilter = {
+        from: 10200000,
+        to: 10400000,
+        windowSize: 200000
+      };
+
+      let result = isOverlapping(newTimeFilter, preTimeFilter);
+      expect(result).to.equal(false);
+    });
+
+    it('should not find innerlap', function() {
+      let newTimeFilter: TimeFilter = {
+        from: 10400000,
+        to: 10500000,
+        windowSize: 100000
+      };
+
+      let result = isOverlapping(newTimeFilter, preTimeFilter);
+      expect(result).to.equal(true); // TODO false ? as seen in description
+    });
+
+    it('should not find after outerlap', function() {
+      let newTimeFilter: TimeFilter = {
+        from: 10700000,
+        to: 10800000,
+        windowSize: 100000
+      };
+
+      let result = isOverlapping(newTimeFilter, preTimeFilter);
+      expect(result).to.equal(false);
+    });
+
+    it('should not find before outerlap', function() {
+      let newTimeFilter: TimeFilter = {
+        from: 10100000,
+        to: 10200000,
+        windowSize: 100000
+      };
+
+      let result = isOverlapping(newTimeFilter, preTimeFilter);
+      expect(result).to.equal(false);
+    });
+  });
+
+  describe('with a target', function() {
+    let target = buildTestTarget("SUM");
+
+    it('should generate a stable hash', function() {
+      let result = generateStableHash(target);
+      expect(result).to.equal(JSON.stringify({
+        entity: "key",
+        service: null,
+        query: "query",
+        filter: null
+      }));
+    });
+
+    it('should have Selectable flattened', function() {
+      let result = generateStableHash(target);
+      expect(result).to.equal(JSON.stringify({
+        entity: "key",
+        service: null,
+        query: "query",
+        filter: null
+      }));
+    });
+  });
+
+  describe('with new data', function() {
+
+    it('should override cached data with new data', function() {
+      let deltaData = generateTestData(2, 2);
+      let cachedData = generateTestData(2, 20);
+
+      let result = appendData(deltaData, cachedData);
+
+      expect(result[0].datapoints.length).to.equal(20);
+      expect(result[0].datapoints[0]).to.equal(deltaData[0].datapoints[0]);
+      expect(result[0].datapoints[1]).to.equal(deltaData[0].datapoints[1]);
+      expect(result[0].datapoints[2]).to.equal(cachedData[0].datapoints[2]); // ...
+
+      expect(result[1].datapoints.length).to.equal(20);
+      expect(result[1].datapoints[0]).to.equal(deltaData[0].datapoints[0]);
+      expect(result[1].datapoints[1]).to.equal(deltaData[0].datapoints[1]);
+      expect(result[1].datapoints[2]).to.equal(cachedData[0].datapoints[2]); // ...
+    });
+
+    it('should add new data to cache', function() {
+      let deltaData = generateTestData(2, 2);
+      let cachedData = generateTestData(1, 20);
+
+      let result = appendData(deltaData, cachedData);
+
+      expect(result[0].datapoints.length).to.equal(20);
+      expect(result[0].datapoints[0]).to.equal(deltaData[0].datapoints[0]);
+      expect(result[0].datapoints[1]).to.equal(deltaData[0].datapoints[1]);
+      expect(result[0].datapoints[2]).to.equal(cachedData[0].datapoints[2]); // ...
+
+      expect(result[1].datapoints.length).to.equal(2);
+      expect(result[1].datapoints[0]).to.equal(deltaData[0].datapoints[0]);
+      expect(result[1].datapoints[1]).to.equal(deltaData[0].datapoints[1]);
+    });
+
+    it('should remain cached data if not updated', function() {
+      let deltaData = generateTestData(1, 2);
+      let cachedData = generateTestData(2, 20);
+
+      let result = appendData(deltaData, cachedData);
+
+      expect(result[0].datapoints.length).to.equal(20);
+      expect(result[0].datapoints[0]).to.equal(deltaData[0].datapoints[0]);
+      expect(result[0].datapoints[1]).to.equal(deltaData[0].datapoints[1]);
+      expect(result[0].datapoints[2]).to.equal(cachedData[0].datapoints[2]); // ...
+
+      expect(result[1].datapoints.length).to.equal(20);
+      expect(result[1].datapoints[0]).to.equal(cachedData[0].datapoints[0]);
+      expect(result[1].datapoints[1]).to.equal(cachedData[0].datapoints[1]);
+      expect(result[1].datapoints[2]).to.equal(cachedData[0].datapoints[2]); // ...
+    });
+  });
+});
+
+/*
+ * Return testdata with random values (sometimes null) and a decreasing timestamp.
+ */
+function generateTestData(amountOfTimeseries, numberOfEntries) {
+  var data = [];
+  for (let i = 1; i <= amountOfTimeseries; i++) {
+    var timeseries = [];
+    for (let j = 1; j <= numberOfEntries; j++) {
+      timeseries.push([getRandomValue(), 10900000 - (j * 100000)]);
+    }
+    data.push({
+      target: "Metrics for " + amountOfTimeseries,
+      refId: "A",
+      datapoints: timeseries
+    });
+  }
+  return data;
+}
+
+function getRandomValue(): integer {
+  // return null once in a while
+  if (Math.floor(Math.random() * 5) == 0) {
+    return null;
+  }
+  return Math.floor(Math.random() * 100);
+}
+
+function buildTestTarget(aggregationFunctionLabel) {
+  return {
+    entity: { key: "key", label: "label" },
+    service: { key: null, label: "-----" },
+    query: "query",
+    filter: null,
+    pluginId: "pluginId",
+    showWarningCantShowAllResults: "showWarningCantShowAllResults",
+    labelFormat: "labelFormat",
+    timeShiftIsValid: "timeShiftIsValid",
+    useFreeTextMetrics: "useFreeTextMetrics",
+    showGroupBySecondLevel: "showGroupBySecondLevel",
+    aggregateGraphs: "aggregateGraphs",
+    canShowAllMetrics: "canShowAllMetrics",
+    timeFilter: "timeFilter",
+    stableHash: "stableHash",
+    refId: "A"
+  };
+}

--- a/specs/delta_specs.ts
+++ b/specs/delta_specs.ts
@@ -96,51 +96,65 @@ describe('Given a delta', function() {
       let deltaData = generateTestData(2, 2);
       let cachedData = generateTestData(2, 20);
 
-      let result = appendData(deltaData, cachedData);
+      let result = appendData(_.cloneDeep(deltaData), _.cloneDeep(cachedData));
 
       expect(result[0].datapoints.length).to.equal(20);
-      expect(result[0].datapoints[0]).to.equal(deltaData[0].datapoints[0]);
-      expect(result[0].datapoints[1]).to.equal(deltaData[0].datapoints[1]);
-      expect(result[0].datapoints[2]).to.equal(cachedData[0].datapoints[2]); // ...
+      expect(result[0].datapoints[19]).to.equal(deltaData[0].datapoints[1]);
+      expect(result[0].datapoints[18]).to.equal(deltaData[0].datapoints[0]);
+      expect(result[0].datapoints[17]).to.equal(cachedData[0].datapoints[17]); // ...
 
       expect(result[1].datapoints.length).to.equal(20);
-      expect(result[1].datapoints[0]).to.equal(deltaData[0].datapoints[0]);
-      expect(result[1].datapoints[1]).to.equal(deltaData[0].datapoints[1]);
-      expect(result[1].datapoints[2]).to.equal(cachedData[0].datapoints[2]); // ...
+      expect(result[1].datapoints[19]).to.equal(deltaData[1].datapoints[1]);
+      expect(result[1].datapoints[18]).to.equal(deltaData[1].datapoints[0]);
+      expect(result[1].datapoints[17]).to.equal(cachedData[1].datapoints[17]); // ...
     });
 
-    it('should add new data to cache', function() {
+    it('should add completly new data to cache', function() {
       let deltaData = generateTestData(2, 2);
       let cachedData = generateTestData(1, 20);
 
-      let result = appendData(deltaData, cachedData);
+      let result = appendData(_.cloneDeep(deltaData), _.cloneDeep(cachedData));
 
       expect(result[0].datapoints.length).to.equal(20);
-      expect(result[0].datapoints[0]).to.equal(deltaData[0].datapoints[0]);
-      expect(result[0].datapoints[1]).to.equal(deltaData[0].datapoints[1]);
-      expect(result[0].datapoints[2]).to.equal(cachedData[0].datapoints[2]); // ...
+      expect(result[0].datapoints[19]).to.equal(deltaData[0].datapoints[1]);
+      expect(result[0].datapoints[18]).to.equal(deltaData[0].datapoints[0]);
+      expect(result[0].datapoints[17]).to.equal(cachedData[0].datapoints[17]); // ...
 
       expect(result[1].datapoints.length).to.equal(2);
-      expect(result[1].datapoints[0]).to.equal(deltaData[0].datapoints[0]);
-      expect(result[1].datapoints[1]).to.equal(deltaData[0].datapoints[1]);
+      expect(result[1].datapoints[1]).to.equal(deltaData[1].datapoints[1]);
+      expect(result[1].datapoints[0]).to.equal(deltaData[1].datapoints[0]);
     });
 
-    it('should remain cached data if not updated', function() {
+    it('should still contain cached data if not updated', function() {
       let deltaData = generateTestData(1, 2);
       let cachedData = generateTestData(2, 20);
 
-      let result = appendData(deltaData, cachedData);
+      let result = appendData(_.cloneDeep(deltaData), _.cloneDeep(cachedData));
 
       expect(result[0].datapoints.length).to.equal(20);
-      expect(result[0].datapoints[0]).to.equal(deltaData[0].datapoints[0]);
-      expect(result[0].datapoints[1]).to.equal(deltaData[0].datapoints[1]);
-      expect(result[0].datapoints[2]).to.equal(cachedData[0].datapoints[2]); // ...
+      expect(result[0].datapoints[19]).to.equal(deltaData[0].datapoints[1]);
+      expect(result[0].datapoints[18]).to.equal(deltaData[0].datapoints[0]);
+      expect(result[0].datapoints[17]).to.equal(cachedData[0].datapoints[17]); // ...
 
       expect(result[1].datapoints.length).to.equal(20);
-      expect(result[1].datapoints[0]).to.equal(cachedData[0].datapoints[0]);
-      expect(result[1].datapoints[1]).to.equal(cachedData[0].datapoints[1]);
-      expect(result[1].datapoints[2]).to.equal(cachedData[0].datapoints[2]); // ...
+      expect(result[1].datapoints[19]).to.equal(cachedData[1].datapoints[19]);
+      expect(result[1].datapoints[18]).to.equal(cachedData[1].datapoints[18]);
+      expect(result[1].datapoints[17]).to.equal(cachedData[1].datapoints[17]); // ...
     });
+
+    it('should dropp old cached data when new data was added', function() {
+      let deltaData = generateTestData(1, 2);
+      let cachedData = generateTestData(1, 21);
+      cachedData = _.takeRight(cachedData[0].datapoints, 20)
+
+      let result = appendData(_.cloneDeep(deltaData), _.cloneDeep(cachedData));
+
+      expect(result[0].datapoints.length).to.equal(20);
+      expect(result[0].datapoints[19]).to.equal(deltaData[0].datapoints[1]);
+      expect(result[0].datapoints[18]).to.equal(deltaData[0].datapoints[0]);
+      expect(result[0].datapoints[17]).to.equal(cachedData[0].datapoints[17]); // ...
+    });
+
   });
 });
 
@@ -152,7 +166,7 @@ function generateTestData(amountOfTimeseries, numberOfEntries) {
   for (let i = 1; i <= amountOfTimeseries; i++) {
     var timeseries = [];
     for (let j = 1; j <= numberOfEntries; j++) {
-      timeseries.push([getRandomValue(), 10900000 - (j * 100000)]);
+      timeseries.unshift([getRandomValue(), 10900000 - (j * 100000)]);
     }
     data.push({
       target: "Metrics for " + amountOfTimeseries,

--- a/specs/delta_specs.ts
+++ b/specs/delta_specs.ts
@@ -99,14 +99,14 @@ describe('Given a delta', function() {
       let result = appendData(_.cloneDeep(deltaData), _.cloneDeep(cachedData));
 
       expect(result[0].datapoints.length).to.equal(20);
-      expect(result[0].datapoints[19]).to.equal(deltaData[0].datapoints[1]);
-      expect(result[0].datapoints[18]).to.equal(deltaData[0].datapoints[0]);
-      expect(result[0].datapoints[17]).to.equal(cachedData[0].datapoints[17]); // ...
+      expect(result[0].datapoints[19]).to.eql(deltaData[0].datapoints[1]);
+      expect(result[0].datapoints[18]).to.eql(deltaData[0].datapoints[0]);
+      expect(result[0].datapoints[17]).to.eql(cachedData[0].datapoints[17]); // ...
 
       expect(result[1].datapoints.length).to.equal(20);
-      expect(result[1].datapoints[19]).to.equal(deltaData[1].datapoints[1]);
-      expect(result[1].datapoints[18]).to.equal(deltaData[1].datapoints[0]);
-      expect(result[1].datapoints[17]).to.equal(cachedData[1].datapoints[17]); // ...
+      expect(result[1].datapoints[19]).to.eql(deltaData[1].datapoints[1]);
+      expect(result[1].datapoints[18]).to.eql(deltaData[1].datapoints[0]);
+      expect(result[1].datapoints[17]).to.eql(cachedData[1].datapoints[17]); // ...
     });
 
     it('should add completly new data to cache', function() {
@@ -116,13 +116,13 @@ describe('Given a delta', function() {
       let result = appendData(_.cloneDeep(deltaData), _.cloneDeep(cachedData));
 
       expect(result[0].datapoints.length).to.equal(20);
-      expect(result[0].datapoints[19]).to.equal(deltaData[0].datapoints[1]);
-      expect(result[0].datapoints[18]).to.equal(deltaData[0].datapoints[0]);
-      expect(result[0].datapoints[17]).to.equal(cachedData[0].datapoints[17]); // ...
+      expect(result[0].datapoints[19]).to.eql(deltaData[0].datapoints[1]);
+      expect(result[0].datapoints[18]).to.eql(deltaData[0].datapoints[0]);
+      expect(result[0].datapoints[17]).to.eql(cachedData[0].datapoints[17]); // ...
 
       expect(result[1].datapoints.length).to.equal(2);
-      expect(result[1].datapoints[1]).to.equal(deltaData[1].datapoints[1]);
-      expect(result[1].datapoints[0]).to.equal(deltaData[1].datapoints[0]);
+      expect(result[1].datapoints[1]).to.eql(deltaData[1].datapoints[1]);
+      expect(result[1].datapoints[0]).to.eql(deltaData[1].datapoints[0]);
     });
 
     it('should still contain cached data if not updated', function() {
@@ -132,27 +132,27 @@ describe('Given a delta', function() {
       let result = appendData(_.cloneDeep(deltaData), _.cloneDeep(cachedData));
 
       expect(result[0].datapoints.length).to.equal(20);
-      expect(result[0].datapoints[19]).to.equal(deltaData[0].datapoints[1]);
-      expect(result[0].datapoints[18]).to.equal(deltaData[0].datapoints[0]);
-      expect(result[0].datapoints[17]).to.equal(cachedData[0].datapoints[17]); // ...
+      expect(result[0].datapoints[19]).to.eql(deltaData[0].datapoints[1]);
+      expect(result[0].datapoints[18]).to.eql(deltaData[0].datapoints[0]);
+      expect(result[0].datapoints[17]).to.eql(cachedData[0].datapoints[17]); // ...
 
       expect(result[1].datapoints.length).to.equal(20);
-      expect(result[1].datapoints[19]).to.equal(cachedData[1].datapoints[19]);
-      expect(result[1].datapoints[18]).to.equal(cachedData[1].datapoints[18]);
-      expect(result[1].datapoints[17]).to.equal(cachedData[1].datapoints[17]); // ...
+      expect(result[1].datapoints[19]).to.eql(cachedData[1].datapoints[19]);
+      expect(result[1].datapoints[18]).to.eql(cachedData[1].datapoints[18]);
+      expect(result[1].datapoints[17]).to.eql(cachedData[1].datapoints[17]); // ...
     });
 
     it('should dropp old cached data when new data was added', function() {
       let deltaData = generateTestData(1, 2);
       let cachedData = generateTestData(1, 21);
-      cachedData = _.takeRight(cachedData[0].datapoints, 20)
+      cachedData[0].datapoints = _.takeRight(cachedData[0].datapoints, 20)
 
       let result = appendData(_.cloneDeep(deltaData), _.cloneDeep(cachedData));
 
       expect(result[0].datapoints.length).to.equal(20);
-      expect(result[0].datapoints[19]).to.equal(deltaData[0].datapoints[1]);
-      expect(result[0].datapoints[18]).to.equal(deltaData[0].datapoints[0]);
-      expect(result[0].datapoints[17]).to.equal(cachedData[0].datapoints[17]); // ...
+      expect(result[0].datapoints[19]).to.eql(deltaData[0].datapoints[1]);
+      expect(result[0].datapoints[18]).to.eql(deltaData[0].datapoints[0]);
+      expect(result[0].datapoints[17]).to.eql(cachedData[0].datapoints[17]); // ...
     });
 
   });
@@ -169,7 +169,7 @@ function generateTestData(amountOfTimeseries, numberOfEntries) {
       timeseries.unshift([getRandomValue(), 10900000 - (j * 100000)]);
     }
     data.push({
-      target: "Metrics for " + amountOfTimeseries,
+      target: "Metrics for " + i,
       refId: "A",
       datapoints: timeseries
     });

--- a/specs/delta_specs.ts
+++ b/specs/delta_specs.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from './lib/common';
-import { appendData, generateStableHash, isOverlapping } from "../src/util/delta_util";
+import { appendData, generateStableHash, hasIntersection } from "../src/util/delta_util";
 import TimeFilter from '../src/types/time_filter';
 
 describe('Given a delta', function() {
@@ -17,7 +17,7 @@ describe('Given a delta', function() {
         windowSize: 200000
       };
 
-      let result = isOverlapping(newTimeFilter, preTimeFilter);
+      let result = hasIntersection(newTimeFilter, preTimeFilter);
       expect(result).to.equal(true);
     });
 
@@ -28,7 +28,7 @@ describe('Given a delta', function() {
         windowSize: 200000
       };
 
-      let result = isOverlapping(newTimeFilter, preTimeFilter);
+      let result = hasIntersection(newTimeFilter, preTimeFilter);
       expect(result).to.equal(false);
     });
 
@@ -39,7 +39,7 @@ describe('Given a delta', function() {
         windowSize: 100000
       };
 
-      let result = isOverlapping(newTimeFilter, preTimeFilter);
+      let result = hasIntersection(newTimeFilter, preTimeFilter);
       expect(result).to.equal(true); // TODO false ? as seen in description
     });
 
@@ -50,7 +50,7 @@ describe('Given a delta', function() {
         windowSize: 100000
       };
 
-      let result = isOverlapping(newTimeFilter, preTimeFilter);
+      let result = hasIntersection(newTimeFilter, preTimeFilter);
       expect(result).to.equal(false);
     });
 
@@ -61,7 +61,7 @@ describe('Given a delta', function() {
         windowSize: 100000
       };
 
-      let result = isOverlapping(newTimeFilter, preTimeFilter);
+      let result = hasIntersection(newTimeFilter, preTimeFilter);
       expect(result).to.equal(false);
     });
   });

--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -27,7 +27,7 @@ export class InstanaConfigCtrl {
     this.datasourceSrv.loadDatasource(this.current.name).then(datasource => {
       return datasource.getVersion();
     }).then(version => {
-      this.current.jsonData.canQueryOfflineSnapshots = version >= 1.156;
+      this.current.jsonData.canQueryOfflineSnapshots = version >= 156;
     });
   }
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -61,12 +61,9 @@ export default class InstanaDatasource extends AbstractDatasource {
     this.availableRollups = getPossibleRollups(panelTimeFilter);
     this.availableGranularities = getPossibleGranularities(panelTimeFilter.windowSize);
 
-    const targets = [];
-
     return this.$q.all(
       _.map(options.targets, target => {
         let timeFilter: TimeFilter = this.readTime(options);
-        targets[target.refId] = target;
 
         // grafana setting to disable query execution
         if (target.hide) {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -279,8 +279,8 @@ export default class InstanaDatasource extends AbstractDatasource {
     const from = new Date(options.range.from).getTime();
     const to = new Date(options.range.to).getTime();
     return {
-      from: (from / 1000) * 1000,
-      to: (to / 1000) * 1000,
+      from: Math.round(from / 1000) * 1000,
+      to: Math.round(to / 1000) * 1000,
       windowSize: to - from
     };
   }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -123,9 +123,8 @@ export default class InstanaDatasource extends AbstractDatasource {
 
   appendResult(data, target) {
     var cachedResult = this.resultCache.get(target.stableHash);
-    if (cachedResult && cachedResult.results && cachedResult.results.length > 0) {
-      // TODO this is broken as we can have mulitple results for one query
-      data = appendData(data, cachedResult.results[0].datapoints);
+    if (cachedResult && cachedResult.results) {
+      data = appendData(data, cachedResult.results);
     }
     return data;
   }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -105,7 +105,6 @@ export default class InstanaDatasource extends AbstractDatasource {
       })
     ).then(targetData => {
       var result = [];
-      // console.log(JSON.stringify(targetData));
       _.each(targetData, (targetAndData, index) => {
         // Flatten the list as Grafana expects a list of targets with corresponding datapoints.
         var resultData = _.compact(_.flatten(targetAndData.data)); // Also remove empty data items

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -133,10 +133,11 @@ export default class InstanaDatasource extends AbstractDatasource {
     var cachedResult = this.resultCache.get(target.stableHash);
     if (cachedResult && hasIntersection(timeFilter, cachedResult.timeFilter)) {
       var newFrom = this.getDeltaRequestTimestamp(cachedResult.results, cachedResult.timeFilter.from);
+      var newTo = Math.round(timeFilter.to / 10000) * 10000;
       return {
         from: newFrom,
-        to: timeFilter.to,
-        windowSize: timeFilter.to - newFrom
+        to: newTo,
+        windowSize: newTo - newFrom
       };
     }
     return timeFilter;

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -132,7 +132,7 @@ export default class InstanaDatasource extends AbstractDatasource {
   adjustTimeFilterIfCached(timeFilter, target) {
     var cachedResult = this.resultCache.get(target.stableHash);
     if (cachedResult && isOverlapping(timeFilter, cachedResult.timeFilter)) {
-      var newFrom = (this.getLastTimestampOfSeries(cachedResult.results) / 1000) * 1000;
+      var newFrom = Math.round(this.getLastTimestampOfSeries(cachedResult.results) / 1000) * 1000;
       return {
         from: newFrom,
         to: timeFilter.to,

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -76,12 +76,12 @@ export default class InstanaDatasource extends AbstractDatasource {
         // target migration for downwards compatibility
         migrate(target);
 
-        if (!target.metricCategory) {
-          target.metricCategory = this.BUILT_IN_METRICS;
-        }
-
         if (target.timeShift) {
           timeFilter = this.applyTimeShiftOnTimeFilter(timeFilter, this.convertTimeShiftToMillis(target.timeShift));
+        }
+
+        if (!target.metricCategory) {
+          target.metricCategory = this.BUILT_IN_METRICS;
         }
 
         target['timeFilter'] = timeFilter;
@@ -157,7 +157,7 @@ export default class InstanaDatasource extends AbstractDatasource {
   }
 
   buildTargetWithAppendedDataResult(target, timeFilter: TimeFilter, data) {
-    if (timeFilter.from !== target.timeFilter.from) {
+    if (timeFilter.from !== target.timeFilter.from && data) {
       data = this.appendResult(data, target);
     }
     return {
@@ -387,6 +387,8 @@ export default class InstanaDatasource extends AbstractDatasource {
         return readItemMetrics(target, response, this.application.buildApplicationMetricLabel);
       });
     }
+
+    return this.$q.resolve({data: {items: []}});
   }
 
   isInvalidQueryInterval(windowSize: number, queryIntervalLimit: number): boolean {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -65,7 +65,7 @@ export default class InstanaDatasource extends AbstractDatasource {
       _.map(options.targets, target => {
         let timeFilter: TimeFilter = this.readTime(options);
 
-        // grafana setting to disable query execution OR still invalid
+        // grafana setting to disable query execution
         if (target.hide || !target.metricCategory) {
           return { data: [] };
         }
@@ -105,6 +105,7 @@ export default class InstanaDatasource extends AbstractDatasource {
       })
     ).then(targetData => {
       var result = [];
+      // console.log(JSON.stringify(targetData));
       _.each(targetData, (targetAndData, index) => {
         // Flatten the list as Grafana expects a list of targets with corresponding datapoints.
         var resultData = _.compact(_.flatten(targetAndData.data)); // Also remove empty data items
@@ -417,17 +418,17 @@ export default class InstanaDatasource extends AbstractDatasource {
     if (!version) {
         return this.getVersion().then(version => {
           this.resultCache.put('version', version, 3600000); // one hour
-          return version >= 1.171;
+          return version >= 171;
         });
     }
-    return version >= 1.171;
+    return version >= 171;
   }
 
-  getVersion() {
+  getVersion(): number {
     return this.doRequest('/api/instana/version').then(
       result => {
-        if (result.data) {
-          return parseFloat(result.data.imageTag) || null;
+        if (result.data && result.data.imageTag) {
+          return parseInt(result.data.imageTag.split('.', 2)[1], 10) || null;
         }
         return null;
       }, error => {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -76,6 +76,10 @@ export default class InstanaDatasource extends AbstractDatasource {
         // target migration for downwards compatibility
         migrate(target);
 
+        if (!target.metricCategory) {
+          target.metricCategory = this.BUILT_IN_METRICS;
+        }
+
         if (target.timeShift) {
           timeFilter = this.applyTimeShiftOnTimeFilter(timeFilter, this.convertTimeShiftToMillis(target.timeShift));
         }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -130,7 +130,7 @@ export default class InstanaDatasource extends AbstractDatasource {
     var cachedResult = this.resultCache.get(target.stableHash);
     if (cachedResult && hasIntersection(timeFilter, cachedResult.timeFilter)) {
       var newFrom = this.getDeltaRequestTimestamp(cachedResult.results, cachedResult.timeFilter.from);
-      var newTo = Math.round(timeFilter.to / 10000) * 10000;
+      var newTo = Math.floor(timeFilter.to / 10000) * 10000;
       return {
         from: newFrom,
         to: newTo,
@@ -278,8 +278,8 @@ export default class InstanaDatasource extends AbstractDatasource {
     const from = new Date(options.range.from).getTime();
     const to = new Date(options.range.to).getTime();
     return {
-      from: Math.round(from / 1000) * 1000,
-      to: Math.round(to / 1000) * 1000,
+      from: Math.floor(from / 1000) * 1000,
+      to: Math.floor(to / 1000) * 1000,
       windowSize: to - from
     };
   }
@@ -382,7 +382,7 @@ export default class InstanaDatasource extends AbstractDatasource {
 
   isInvalidQueryInterval(windowSize: number, queryIntervalLimit: number): boolean {
     if (queryIntervalLimit > 0) {
-      return Math.round(windowSize / 1000) * 1000 > queryIntervalLimit;
+      return Math.floor(windowSize / 1000) * 1000 > queryIntervalLimit;
     }
     return false;
   }

--- a/src/datasource_abstract.ts
+++ b/src/datasource_abstract.ts
@@ -61,7 +61,7 @@ export default class AbstractDatasource {
   }
 
   private msToMin(time: number): number {
-    return Math.round(time / 60000);
+    return Math.floor(time / 60000);
   }
 
   hoursToMs(hours: any): number {

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -751,7 +751,7 @@ export class InstanaQueryCtrl extends QueryCtrl {
     if (!this.version) {
       return false;
     } else {
-      return this.version >= 1.163;
+      return this.version >= 163;
     }
   }
 }

--- a/src/util/aggregation_util.ts
+++ b/src/util/aggregation_util.ts
@@ -1,11 +1,10 @@
 import _ from 'lodash';
 
 export function aggregateTarget(data, target) {
-  var refId = target.refId;
   var concatedTargetData = concatTargetData(data);
 
-  var dataGroupedByTimestamp = _.groupBy(concatedTargetData, function (data) {
-    return data[1];
+  var dataGroupedByTimestamp = _.groupBy(concatedTargetData, function (d) {
+    return d[1];
   });
 
   var aggregatedData = aggregateDataOfTimestamp(dataGroupedByTimestamp, target.aggregationFunction.label);
@@ -13,7 +12,7 @@ export function aggregateTarget(data, target) {
     return datapoint[1];
   }]);
 
-  return buildResult(aggregatedData, refId, buildAggregationLabel(target));
+  return buildResult(aggregatedData, target.refId, buildAggregationLabel(target));
 }
 
 function concatTargetData(data) {

--- a/src/util/aggregation_util.ts
+++ b/src/util/aggregation_util.ts
@@ -1,6 +1,42 @@
 import _ from 'lodash';
 
-export function aggregate(aggregation: string, data) {
+export function aggregateTarget(data, target) {
+  var refId = target.refId;
+  var concatedTargetData = concatTargetData(data);
+
+  var dataGroupedByTimestamp = _.groupBy(concatedTargetData, function (data) {
+    return data[1];
+  });
+
+  var aggregatedData = aggregateDataOfTimestamp(dataGroupedByTimestamp, target.aggregationFunction.label);
+  aggregatedData = _.sortBy(aggregatedData, [function (datapoint) {
+    return datapoint[1];
+  }]);
+
+  return buildResult(aggregatedData, refId, buildAggregationLabel(target));
+}
+
+function concatTargetData(data) {
+  var result = [];
+  _.each(data, (entry, index) => {
+    result = _.concat(result, entry.datapoints);
+  });
+  return result;
+}
+
+function aggregateDataOfTimestamp(dataGroupedByTimestamp, aggregationLabel: string) {
+  var result = [];
+  _.each(dataGroupedByTimestamp, (timestampData, timestamp) => {
+    var valuesOfTimestamp = _.map(timestampData, (datapoint, index) => {
+      return datapoint[0];
+    });
+    var aggregatedValue = aggregate(aggregationLabel, valuesOfTimestamp);
+    result.push([aggregatedValue, parseInt(timestamp)]);
+  });
+  return result;
+}
+
+function aggregate(aggregation: string, data) {
   if (aggregation.toLowerCase() === "sum") {
     return _.sum(data);
   } else if (aggregation.toLowerCase() === "mean") {
@@ -15,7 +51,15 @@ export function aggregate(aggregation: string, data) {
   }
 }
 
-export function buildAggregationLabel(target) {
+function buildResult(aggregatedData, refId, target) {
+  return {
+    datapoints: aggregatedData,
+    refId: refId,
+    target: target
+  };
+}
+
+function buildAggregationLabel(target) {
   if (target.showAllMetrics) {
     if (target.allMetrics.length > 1) {
       if (target.customFilters && target.customFilters.length > 0) {

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -8,11 +8,21 @@ const omitLabels = [
   'timeShiftIsValid',
   'useFreeTextMetrics',
   'showGroupBySecondLevel',
-  'aggregateGraphs'
+  'aggregateGraphs',
+  'canShowAllMetrics',
+  'timeFilter',
+  'stableHash'
 ];
 
 export function generateStableHash(obj) {
-  var pseudoHash = _.omit(obj, omitLabels);
+  let pseudoHash = _.omit(obj, omitLabels);
+  pseudoHash = _.mapValues(pseudoHash, value => {
+      // to reduce weight of interface Selectable
+      if (value != null && typeof value === 'object' && 'key' in value) {
+        value = value.key;
+      }
+      return value;
+  });
   return JSON.stringify(pseudoHash);
 }
 

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -45,7 +45,7 @@ from |----------------------------------------| to (t1)
   from |-------------------| to (t2)
                         from |-------------------| to (t1)
 */
-export function isOverlapping(t1: TimeFilter, t2: TimeFilter): boolean {
+export function hasIntersection(t1: TimeFilter, t2: TimeFilter): boolean {
   return t1.from < t2.to && t1.from > t2.from; // t1.windowSize === t2.windowSize
 }
 

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 
+import TimeFilter from '../types/time_filter';
+
 const omitLabels = [
   'refId',
   'pluginId',
@@ -10,11 +12,12 @@ const omitLabels = [
   'showGroupBySecondLevel',
   'aggregateGraphs',
   'canShowAllMetrics',
+  'aggregationFunction',
   'timeFilter',
   'stableHash'
 ];
 
-export function generateStableHash(obj) {
+export function generateStableHash(obj): string {
   let pseudoHash = _.omit(obj, omitLabels);
   pseudoHash = _.mapValues(pseudoHash, value => {
       // to reduce overhead of interface Selectable
@@ -42,10 +45,8 @@ from |----------------------------------------| to (t1)
   from |-------------------| to (t2)
                         from |-------------------| to (t1)
 */
-export function isOverlapping(t1, t2) {
-  return t1.windowSize === t2.windowSize
-        && t1.from < t2.to
-        && t1.from > t2.from;
+export function isOverlapping(t1: TimeFilter, t2: TimeFilter): boolean {
+  return t1.from < t2.to && t1.from > t2.from; // t1.windowSize === t2.windowSize
 }
 
 /*
@@ -53,7 +54,7 @@ export function isOverlapping(t1, t2) {
   Also removes old data accordingly (e.g. if 4 new datapoints were added,
   the corresponding oldest four datapoints are removed).
 */
-export function appendData(newData, cachedData) {
+export function appendData(newData, cachedData): any {
   _.each(newData, (targetData, index) => {
     var appendedData = _.find(cachedData, function(o) { return o.target === targetData.target; });
     if (appendedData) {
@@ -72,6 +73,5 @@ export function appendData(newData, cachedData) {
       newData[index].datapoints = _.slice(appendedData.datapoints, numberOfNewPoints, appendedData.datapoints.length);
     }
   });
-
   return newData;
 }

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -1,10 +1,19 @@
 import _ from 'lodash';
 
+const omitLabels = [
+  'refId',
+  'pluginId',
+  'showWarningCantShowAllResults',
+  'labelFormat',
+  'timeShiftIsValid',
+  'useFreeTextMetrics',
+  'showGroupBySecondLevel',
+  'aggregateGraphs'
+];
+
 export function generateStableHash(obj) {
-  //var bla = JSON.stringify(obj);
-  //console.log(bla);
-  return "test";
-  //return bla;
+  var pseudoHash = _.omit(obj, omitLabels);
+  return JSON.stringify(pseudoHash);
 }
 
 /*
@@ -27,4 +36,31 @@ export function isOverlapping(t1, t2) {
   return t1.windowSize === t2.windowSize
         && t1.from < t2.to
         && t1.from > t2.from;
+}
+
+/*
+  Appends new found items to already existing data in cache.
+  Also removes old data accordingly (e.g. if 4 new datapoints were added,
+  the corresponding oldest four datapoints are removed).
+*/
+export function appendData(newData, cachedDatapoints) {
+  _.each(newData, (targetData, index) => {
+    var appendedData = cachedDatapoints;
+    var numberOfNewPoints = 0;
+
+    _.each(targetData.datapoints, (datapoint, index) => {
+      //add or replace value for timestamp
+      var d = _.find(appendedData, function(o)  {  return  o[1] === datapoint[1];  });
+      if (d) {
+        d[0] = datapoint[0];
+      } else {
+        appendedData.push(datapoint);
+        numberOfNewPoints++;
+      }
+    });
+
+    newData[index].datapoints = _.slice(appendedData, numberOfNewPoints, appendedData.length);
+  });
+
+  return newData;
 }

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -1,0 +1,42 @@
+import _ from 'lodash';
+
+export function generateStableHash(obj) {
+  if (obj === undefined) {
+    return 'undefined';
+  } else if (obj == null) {
+    return 'null';
+  } else if (obj instanceof Array) {
+    return '[' + obj.map(v => (v === undefined ? 'null' : generateStableHash(v))).join(',') + ']';
+  } else if (typeof obj === 'object') {
+    const values = Object.keys(obj)
+      .sort()
+      .filter(k => obj[k] !== undefined)
+      .map(k => `"${k}":${generateStableHash(obj[k])}`)
+      .join(',');
+
+    return `{${values}}`;
+  }
+  return JSON.stringify(obj);
+}
+
+/*
+  Check if two time filters are overlapping.
+
+  Return true when:
+
+  from |-------------------| to (t2)
+              from |--------------------| to (t1)
+
+  Returns false when:
+
+     from |-------------------| to (t2)
+from |----------------------------------------| to (t1)
+
+  from |-------------------| to (t2)
+                        from |-------------------| to (t1)
+*/
+export function isOverlapping(t1, t2) {
+  return t1.windowSize === t2.windowSize
+        && t1.from < t2.to
+        && t1.from > t2.from;
+}

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -54,24 +54,17 @@ export function isOverlapping(t1: TimeFilter, t2: TimeFilter): boolean {
   Also removes old data accordingly (e.g. if 4 new datapoints were added,
   the corresponding oldest four datapoints are removed).
 */
-export function appendData(newData, cachedData): any {
-  _.each(newData, (targetData, index) => {
-    var appendedData = _.find(cachedData, function(o) { return o.target === targetData.target; });
-    if (appendedData) {
-      var numberOfNewPoints = 0;
-      _.each(targetData.datapoints, (datapoint, index) => {
-        //add or replace value for timestamp
-        var d = _.find(appendedData.datapoints, function(o)  {  return  o[1] === datapoint[1];  });
-        if (d) {
-          d[0] = datapoint[0];
-        } else {
-          appendedData.datapoints.push(datapoint);
-          numberOfNewPoints++;
-        }
-      });
-
-      newData[index].datapoints = _.slice(appendedData.datapoints, numberOfNewPoints, appendedData.datapoints.length);
+export function appendData(newDeltaData, cachedData): any {
+  _.each(newDeltaData, (deltaData, index) => {
+    var matchingCachedData = _.find(cachedData, o => o.target === deltaData.target);
+    if (matchingCachedData && deltaData.datapoints) {
+      const size = matchingCachedData.datapoints.length;
+      let datapoints = deltaData.datapoints.concat(matchingCachedData.datapoints);
+      datapoints = _.sortedUniqBy(datapoints.sort((a, b) => a[1] - b[1]), a => a[1]);
+      matchingCachedData.datapoints = _.takeRight(datapoints, size);
+    } else {
+      cachedData.push(deltaData);
     }
   });
-  return newData;
+  return cachedData;
 }

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -69,7 +69,7 @@ export function appendData(newData, cachedData) {
         }
       });
 
-      newData[index].datapoints = _.slice(.datapoints, numberOfNewPoints, appendedData.datapoints.length);
+      newData[index].datapoints = _.slice(appendedData.datapoints, numberOfNewPoints, appendedData.datapoints.length);
     }
   });
 

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -1,22 +1,10 @@
 import _ from 'lodash';
 
 export function generateStableHash(obj) {
-  if (obj === undefined) {
-    return 'undefined';
-  } else if (obj == null) {
-    return 'null';
-  } else if (obj instanceof Array) {
-    return '[' + obj.map(v => (v === undefined ? 'null' : generateStableHash(v))).join(',') + ']';
-  } else if (typeof obj === 'object') {
-    const values = Object.keys(obj)
-      .sort()
-      .filter(k => obj[k] !== undefined)
-      .map(k => `"${k}":${generateStableHash(obj[k])}`)
-      .join(',');
-
-    return `{${values}}`;
-  }
-  return JSON.stringify(obj);
+  //var bla = JSON.stringify(obj);
+  //console.log(bla);
+  return "test";
+  //return bla;
 }
 
 /*

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -17,7 +17,7 @@ const omitLabels = [
 export function generateStableHash(obj) {
   let pseudoHash = _.omit(obj, omitLabels);
   pseudoHash = _.mapValues(pseudoHash, value => {
-      // to reduce weight of interface Selectable
+      // to reduce overhead of interface Selectable
       if (value != null && typeof value === 'object' && 'key' in value) {
         value = value.key;
       }
@@ -53,23 +53,24 @@ export function isOverlapping(t1, t2) {
   Also removes old data accordingly (e.g. if 4 new datapoints were added,
   the corresponding oldest four datapoints are removed).
 */
-export function appendData(newData, cachedDatapoints) {
+export function appendData(newData, cachedData) {
   _.each(newData, (targetData, index) => {
-    var appendedData = cachedDatapoints;
-    var numberOfNewPoints = 0;
+    var appendedData = _.find(cachedData, function(o) { return o.target === targetData.target; });
+    if (appendedData) {
+      var numberOfNewPoints = 0;
+      _.each(targetData.datapoints, (datapoint, index) => {
+        //add or replace value for timestamp
+        var d = _.find(appendedData.datapoints, function(o)  {  return  o[1] === datapoint[1];  });
+        if (d) {
+          d[0] = datapoint[0];
+        } else {
+          appendedData.datapoints.push(datapoint);
+          numberOfNewPoints++;
+        }
+      });
 
-    _.each(targetData.datapoints, (datapoint, index) => {
-      //add or replace value for timestamp
-      var d = _.find(appendedData, function(o)  {  return  o[1] === datapoint[1];  });
-      if (d) {
-        d[0] = datapoint[0];
-      } else {
-        appendedData.push(datapoint);
-        numberOfNewPoints++;
-      }
-    });
-
-    newData[index].datapoints = _.slice(appendedData, numberOfNewPoints, appendedData.length);
+      newData[index].datapoints = _.slice(.datapoints, numberOfNewPoints, appendedData.datapoints.length);
+    }
   });
 
   return newData;

--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,7 @@
     "max-line-length": [true, 140],
     "member-access": false,
     "no-arg": true,
-    "no-bitwise": true,
+    "no-bitwise": false,
     "no-console": [true,
       "debug",
       "info",


### PR DESCRIPTION
# why
large time-window dashboards getting refreshed often causing a high load. resulting in long reponse times.
# what
add a cache for already queried results and get small delate requests instead.