### PR TITLE
Fix incorrect labels being shown for custom metrics in JVM/MicroMeter…

### DIFF
--- a/src/datasource_infrastructure.ts
+++ b/src/datasource_infrastructure.ts
@@ -52,7 +52,7 @@ export default class InstanaInfrastructureDataSource extends AbstractDatasource 
     metrics = this.doRequest(`/api/infrastructure-monitoring/catalog/metrics/${plugin.key}?filter=${filter}`).then(catalogResponse =>
       catalogResponse.data.map(entry => ({
         'key': entry.metricId,
-        'label': metricCategory === entry.label,
+        'label': entry.label,
         'aggregations': ['MEAN', 'SUM'],
         'entityType': entry.pluginId
       }))

--- a/src/datasource_infrastructure.ts
+++ b/src/datasource_infrastructure.ts
@@ -52,7 +52,7 @@ export default class InstanaInfrastructureDataSource extends AbstractDatasource 
     metrics = this.doRequest(`/api/infrastructure-monitoring/catalog/metrics/${plugin.key}?filter=${filter}`).then(catalogResponse =>
       catalogResponse.data.map(entry => ({
         'key': entry.metricId,
-        'label': metricCategory === this.CUSTOM_METRICS ? entry.description : entry.label, // custom-in metrics have shorter descriptions
+        'label': metricCategory === entry.label,
         'aggregations': ['MEAN', 'SUM'],
         'entityType': entry.pluginId
       }))


### PR DESCRIPTION
I'm trying to show custom metrics from Spring Boot apps.  The dropdown only shows an endless list of "Custom Micrometer counter" and "Custom Micrometer timer" that make it impossible to find the metric you're looking for (there are 1000+ in my case).

The fix is to show the "label", not the "description", because for some reason MicroMeter does not generate useful descriptions.