### PR TITLE
Fix label issues by storing delta cache key inside of result

### DIFF
--- a/specs/datasource_specs.ts
+++ b/specs/datasource_specs.ts
@@ -365,7 +365,7 @@ describe('Given an InstanaDatasource', function() {
       }, timeFilter)
       .then(function(results) {
         expect(results.length).to.equal(2);
-        expect(results[0]).to.eql({ snapshotId: 'A', host: 'Stans-Macbook-Pro', response: { status: 200, data: { label: 'label for A (on host "Stans-Macbook-Pro")' }}});
+        expect(results[0]).to.eql({ snapshotId: 'A', host: 'Stans-Macbook-Pro', response: { status: 200, data: { label: 'label for A' }}});
         expect(results[1]).to.eql({ snapshotId: 'B', host: '', response: { status: 200, data: { label: 'label for B' }}});
       });
     })

--- a/specs/delta_specs.ts
+++ b/specs/delta_specs.ts
@@ -171,7 +171,8 @@ function generateTestData(amountOfTimeseries, numberOfEntries) {
     data.push({
       target: "Metrics for " + i,
       refId: "A",
-      datapoints: timeseries
+      datapoints: timeseries,
+      key: "Metrics for " + i
     });
   }
   return data;

--- a/src/datasource_infrastructure.ts
+++ b/src/datasource_infrastructure.ts
@@ -80,7 +80,6 @@ export default class InstanaInfrastructureDataSource extends AbstractDatasource 
       return snapshots;
     }
 
-    const windowSize = this.getWindowSize(timeFilter);
     const fetchSnapshotContextsUrl = `/api/snapshots/context` +
       `?q=${query}` +
       `&from=${timeFilter.from}` +
@@ -185,7 +184,8 @@ export default class InstanaInfrastructureDataSource extends AbstractDatasource 
         var result = {
           'target': this.buildLabel(snapshot.response, snapshot.host, target, index, metric),
           'datapoints': _.map(timeseries, value => [value.value, value.timestamp]),
-          'refId': target.refId
+          'refId': target.refId,
+          'key': target.stableHash
         };
 
         if (target.displayMaxMetricValue) {
@@ -211,10 +211,13 @@ export default class InstanaInfrastructureDataSource extends AbstractDatasource 
       return [maxValue, series.timestamp];
     });
 
+    var maxLabel = this.convertMetricNameToMaxLabel(target.metric);
+
     return {
-      'target': resultLabel + ' ' + this.convertMetricNameToMaxLabel(target.metric),
+      'target': resultLabel + ' ' + maxLabel,
       'datapoints': datapoints,
-      'refId': target.refId
+      'refId': target.refId,
+      'key': target.stableHash + maxLabel
     };
   }
 

--- a/src/util/analyze_util.ts
+++ b/src/util/analyze_util.ts
@@ -30,7 +30,8 @@ export function readItemMetrics(target, response, getLabel) {
       return {
         'target': getLabel(target, item, key, index),
         'datapoints': _.map(value, metric => [metric[1], metric[0]]),
-        'refId': target.refId
+        'refId': target.refId,
+        'key': target.stableHash
       };
     });
   }));

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -56,12 +56,13 @@ export function hasIntersection(t1: TimeFilter, t2: TimeFilter): boolean {
 */
 export function appendData(newDeltaData, cachedData): any {
   _.each(newDeltaData, (deltaData, index) => {
-    var matchingCachedData = _.find(cachedData, o => o.target === deltaData.target);
+    var matchingCachedData = _.find(cachedData, o => o.key === deltaData.key);
     if (matchingCachedData && deltaData.datapoints) {
       const size = matchingCachedData.datapoints.length;
       let datapoints = deltaData.datapoints.concat(matchingCachedData.datapoints);
       datapoints = _.sortedUniqBy(datapoints.sort((a, b) => a[1] - b[1]), a => a[1]);
       matchingCachedData.datapoints = _.takeRight(datapoints, size);
+      matchingCachedData.target = deltaData.target;
     } else {
       cachedData.push(deltaData);
     }


### PR DESCRIPTION
This PR fixes a label bug that would create duplicate labels (for application as well as infrastructure monitoring).