### PR TITLE
Instana query variables interpolation

### DIFF
--- a/dist/datasource.ts
+++ b/dist/datasource.ts
@@ -68,6 +68,9 @@ export default class InstanaDatasource extends AbstractDatasource {
 
     return this.$q.all(
       _.map(options.targets, target => {
+
+        target.entityQuery = this.templateSrv.replace(target.entityQuery, options.scopedVars);
+
         let timeFilter: TimeFilter = this.readTime(options);
 
         // grafana setting to disable query execution


### PR DESCRIPTION
Thanks for this plugin!

In my daily usage I am trying to use Grafana variables in my Instana queries, but so far they are not working.

As documented [here](https://grafana.com/docs/grafana/latest/developers/plugins/add-support-for-variables/#interpolate-variables-in-data-source-plugins) it is possible to add this feature by invoking the `TemplateSrv` object in the `query` function of a Datasource.

This PR aims to add this feature to the plugin. Alas, I was not able to add new unit test for testing the feature because I am not very familiar with the codebase.

At least, I hope this PR would work as a idea/proposal of adding this helpful feature to the plugin.

Thanks!