### PR TITLE
Show all configured websites in dropdown

### DIFF
--- a/src/GlobalVariables.ts
+++ b/src/GlobalVariables.ts
@@ -16,6 +16,7 @@ export const SLO_INFORMATION = 7;
 
 /* DROPDOWN DEFAULTS */
 export const ALL_APPLICATIONS = '-- No Application Filter --';
+export const ALL_WEBSITES = '-- No Website Filter --';
 export const ALL_SERVICES = '-- No Service Filter --';
 export const ALL_ENDPOINTS = '-- No Endpoint Filter --';
 

--- a/src/components/Analyze/WebsiteMetrics.tsx
+++ b/src/components/Analyze/WebsiteMetrics.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent } from 'react';
 
-import { ANALYZE_WEBSITE_METRICS } from '../../GlobalVariables';
+import {  ALL_WEBSITES, ANALYZE_WEBSITE_METRICS } from '../../GlobalVariables';
 import { DataSource } from '../../datasources/DataSource';
 import { InstanaQuery } from '../../types/instana_query';
 import beacon_types from '../../lists/beacon_types';
@@ -40,11 +40,14 @@ export class WebsiteMetrics extends React.Component<Props, WebsiteMetricsState> 
     isUnmounting = false;
     datasource.fetchWebsites().then((websites) => {
       if (!isUnmounting) {
+        if (!_.find(websites, { key: null })) {
+          websites.unshift({ key: null, label: ALL_WEBSITES });
+        }
+
         this.setState({
           websites: websites,
         });
 
-        // select the most loaded website for default/replacement
         if ((!query.entity || !query.entity.key) && websites) {
           query.entity = websites[0];
         } else if (query.entity && !_.find(websites, ['key', query.entity.key])) {

--- a/src/datasources/DataSource_Website.ts
+++ b/src/datasources/DataSource_Website.ts
@@ -54,43 +54,16 @@ export class DataSourceWebsite {
 
   getWebsites(timeFilter: TimeFilter) {
     const key = getTimeKey(timeFilter);
-
     let websites = this.websitesCache.get(key);
     if (websites) {
       return websites;
     }
 
-    const windowSize = getWindowSize(timeFilter);
-    const data: BeaconGroupBody = {
-      group: {
-        groupbyTag: 'beacon.website.name',
-      },
-      timeFrame: {
-        to: timeFilter.to,
-        windowSize: windowSize,
-      },
-      type: 'PAGELOAD',
-      metrics: [
-        {
-          metric: 'pageLoads',
-          aggregation: 'SUM',
-        },
-      ],
-      order: {
-        by: 'pageLoads',
-        direction: 'desc',
-      },
-      pagination: {
-        ingestionTime: 0,
-        offset: 0,
-        retrievalSize: 200,
-      },
-    };
-    websites = postRequest(this.instanaOptions, '/api/website-monitoring/analyze/beacon-groups', data).then(
+    websites = getRequest(this.instanaOptions, '/api/website-monitoring/config').then(
       (websitesResponse: any) =>
-        websitesResponse.data.items.map((entry: any) => ({
-          key: entry.name,
-          label: entry.name,
+        websitesResponse.data.map((website: any) => ({
+          key: website.name, // use name as key because a website name can only be configured once
+          label: website.name,
         }))
     );
     this.websitesCache.put(key, websites, 600000);


### PR DESCRIPTION
Avoid showing only the "active" websites but instead show all websites that have been configured. Also, switch websites automatically but show a generic first option instead in case a configured website cannot be found anymore.