### PR TITLE
Use new API for Instana requests that go above version 191

### DIFF
--- a/specs/mb/imposters/calls_application.ejs
+++ b/specs/mb/imposters/calls_application.ejs
@@ -55,6 +55,25 @@
   "predicates": [{
     "equals": {
       "method": "GET",
+      "path": "/api/application-monitoring/catalog"
+    }
+  }],
+  "responses": [{
+    "is": {
+      "statusCode": 200,
+      "headers": {
+        "Content-Type": "application/json;charset=utf-8",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE"
+      },
+      "body": "{ \"tagTree\": [], tags: [{ \"name\": \"endpoint.name\", \"type\": \"STRING\", \"category\": \"INSTANA\" }, { \"name\": \"host.ip\", \"type\": \"NUMBER\", \"category\": \"SYSTEM\" }, { \"name\": \"log.level\", \"type\": \"STRING\", \"category\": \"LOG\" }, { \"name\": \"call.latency\", \"type\": \"NUMBER\", \"category\": \"CALL\" }]}"
+    }
+  }]
+},
+{
+  "predicates": [{
+    "equals": {
+      "method": "GET",
       "path": "/api/application-monitoring/catalog/tags"
     }
   }],

--- a/src/components/Analyze/ApplicationCallsMetrics.tsx
+++ b/src/components/Analyze/ApplicationCallsMetrics.tsx
@@ -69,7 +69,7 @@ export class ApplicationCallsMetrics extends React.Component<Props, ApplicationC
       }
     });
 
-    datasource.dataSourceApplication.getApplicationTags().then((applicationTags: any) => {
+    datasource.fetchApplicationTags().then((applicationTags: any) => {
       if (!isUnmounting) {
         this.props.updateGroups(_.sortBy(applicationTags, 'key'));
 

--- a/src/datasources/DataSource.ts
+++ b/src/datasources/DataSource.ts
@@ -299,6 +299,10 @@ export class DataSource extends DataSourceApi<InstanaQuery, InstanaOptions> {
     return this.dataSourceApplication.getApplications(this.getTimeFilter());
   }
 
+  fetchApplicationTags () {
+    return this.dataSourceApplication.getApplicationTags(this.getTimeFilter());
+  }
+
   fetchServices(target: InstanaQuery) {
     return this.dataSourceService.getServicesOfApplication(target, this.getTimeFilter());
   }


### PR DESCRIPTION
This PR changes the current way of getting application tags. It introduces the new API within the datasource. This change is only applied when the underlying Instana backend is at least on version 191. Everything before that will be handled as before.

Old endpoint: `api/application-monitoring/catalog/tags`
New endpoint: `api/application-monitoring/catalog?dataSource=CALLS&useCase=FILTERING&from=` 