### PR TITLE
Only show datapoints relevant for the selected timeframe

### DIFF
--- a/src/datasources/DataSource.ts
+++ b/src/datasources/DataSource.ts
@@ -137,10 +137,16 @@ export class DataSource extends DataSourceApi<InstanaQuery, InstanaOptions> {
       let result: any = [];
       _.each(targetData, (targetAndData) => {
         // Flatten the list as Grafana expects a list of targets with corresponding datapoints.
-        let resultData = _.compact(_.flatten(targetAndData.data)); // Also remove empty data items
+        let resultData: any = _.compact(_.flatten(targetAndData.data)); // Also remove empty data items
         this.cacheResultIfNecessary(_.cloneDeep(resultData), targetAndData.target); // clone to store results without timeshift re-calculation
         this.applyTimeShiftIfNecessary(resultData, targetAndData.target); // adjust resultdata after caching the result
         resultData = this.aggregateDataIfNecessary(resultData, targetAndData.target);
+
+        // only show data that is relevant for the selected timeFrame
+        resultData.forEach((target: any) => {
+          target.datapoints = target.datapoints.filter((d: any) => d[1] >= this.timeFilter.from);
+        });
+
         result.push(resultData);
       });
 
@@ -225,7 +231,7 @@ export class DataSource extends DataSourceApi<InstanaQuery, InstanaOptions> {
     });
   }
 
-  aggregateDataIfNecessary(data: any, target: InstanaQuery) {
+  aggregateDataIfNecessary(data: any, target: InstanaQuery): any[] {
     let newData = [];
 
     if (target.aggregateGraphs) {

--- a/src/datasources/DataSource.ts
+++ b/src/datasources/DataSource.ts
@@ -141,12 +141,6 @@ export class DataSource extends DataSourceApi<InstanaQuery, InstanaOptions> {
         this.cacheResultIfNecessary(_.cloneDeep(resultData), targetAndData.target); // clone to store results without timeshift re-calculation
         this.applyTimeShiftIfNecessary(resultData, targetAndData.target); // adjust resultdata after caching the result
         resultData = this.aggregateDataIfNecessary(resultData, targetAndData.target);
-
-        // only show data that is relevant for the selected timeFrame
-        resultData.forEach((target: any) => {
-          target.datapoints = target.datapoints.filter((d: any) => d[1] >= this.timeFilter.from);
-        });
-
         result.push(resultData);
       });
 
@@ -255,6 +249,26 @@ export class DataSource extends DataSourceApi<InstanaQuery, InstanaOptions> {
       data = this.appendResult(data, target);
     }
 
+    console.log("timeFilter", {
+      from: new Date(timeFilter.from),
+      to: new Date(timeFilter.to)
+    });
+
+    console.log("target.timeFilter", {
+      from: new Date(target.timeFilter.from),
+      to: new Date(target.timeFilter.to)
+    });
+
+    console.log("this.timeFilter", {
+      from: new Date(this.timeFilter.from),
+      to: new Date(this.timeFilter.to)
+    });
+
+    // only show data that is relevant for the selected timeFrame
+    data.forEach((t: any) => {
+      t.datapoints = t.datapoints.filter((d: any) => d[1] >= target.timeFilter.from);
+    });
+
     return {
       target: target,
       data: data,
@@ -286,10 +300,10 @@ export class DataSource extends DataSourceApi<InstanaQuery, InstanaOptions> {
   getDeltaRequestTimestamp(series: any, fromDefault: number): number {
     // the found series can have multiple results, it's ok just to use the first one
     const length = series[0].datapoints.length;
-    if (length < 2) {
+    if (length < 10) {
       return fromDefault;
     }
-    const penultimate = length - 2;
+    const penultimate = length - 10;
     return series[0].datapoints[penultimate][1];
   }
 

--- a/src/datasources/DataSource.ts
+++ b/src/datasources/DataSource.ts
@@ -247,10 +247,7 @@ export class DataSource extends DataSourceApi<InstanaQuery, InstanaOptions> {
   buildTargetWithAppendedDataResult(target: InstanaQuery, timeFilter: TimeFilter, data: any) {
     if (timeFilter.from !== target.timeFilter.from && data) {
       data = this.appendResult(data, target);
-    }
 
-    if (data && data.length > 0) {
-      // only show data that is relevant for the selected timeFrame
       data.forEach((t: any) => {
         t.datapoints = t.datapoints.filter((d: any) => d[1] >= target.timeFilter.from);
       });

--- a/src/datasources/DataSource.ts
+++ b/src/datasources/DataSource.ts
@@ -298,13 +298,19 @@ export class DataSource extends DataSourceApi<InstanaQuery, InstanaOptions> {
   }
 
   getDeltaRequestTimestamp(series: any, fromDefault: number): number {
-    // the found series can have multiple results, it's ok just to use the first one
-    const length = series[0].datapoints.length;
-    if (length < 10) {
-      return fromDefault;
-    }
-    const penultimate = length - 10;
-    return series[0].datapoints[penultimate][1];
+     // the found series can have multiple results, it's ok just to use the first one
+     const length = series[0].datapoints.length;
+     if (length < 2) {
+       return fromDefault;
+     }
+
+     const lastNotNullDatapoint = _.findLast(series[0].datapoints, d => d[0] != null);
+     if (lastNotNullDatapoint) {
+       return lastNotNullDatapoint[1];
+     }
+
+     const penultimate = length - 2;
+     return series[0].datapoints[penultimate][1];
   }
 
   getSloReports(): Promise<SelectableValue[]> {

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -94,3 +94,21 @@ export function appendData(newDeltaData: any, cachedData: any): any {
 
   return cachedData;
 }
+
+export function getDeltaRequestTimestamp(series: any, fromDefault: number, timeInterval: any): number {
+  // we do not apply any delta for requests that contain a one second granularity (application requests)
+  if (timeInterval.key === '1') {
+    return fromDefault;
+  }
+
+  // the found series can have multiple results, it's ok just to use the first one
+  // because data is written in batches and we know that once there is a datapoint
+  // for a series, the other series' datapoints are up-to-date as well.
+  const length = series[0].datapoints.length;
+  if (length < 2) {
+    return fromDefault;
+  }
+
+  const penultimate = length - 2;
+  return series[0].datapoints[penultimate][1];
+}

--- a/src/util/delta_util.ts
+++ b/src/util/delta_util.ts
@@ -77,19 +77,20 @@ export function hasIntersection(t1: TimeFilter, t2: TimeFilter): boolean {
 */
 export function appendData(newDeltaData: any, cachedData: any): any {
   _.each(newDeltaData, (deltaData) => {
-    let matchingCachedData = _.find(cachedData, (o) => o.key === deltaData.key && o.target === deltaData.target);
-    if (matchingCachedData && deltaData.datapoints) {
-      const size = matchingCachedData.datapoints.length;
-      let datapoints = deltaData.datapoints.concat(matchingCachedData.datapoints);
+    let matchingCachedDataIndex = _.findIndex(cachedData, (o: any) => o.key === deltaData.key && o.target === deltaData.target);
+    if (cachedData[matchingCachedDataIndex] && deltaData.datapoints) {
+      // const size = matchingCachedData.datapoints.length;
+      let datapoints = deltaData.datapoints.concat(cachedData[matchingCachedDataIndex].datapoints);
       datapoints = _.sortedUniqBy(
         datapoints.sort((a: any, b: any) => a[1] - b[1]),
         (a: any) => a[1]
       );
-      matchingCachedData.datapoints = _.takeRight(datapoints, size);
-      matchingCachedData.target = deltaData.target;
+      cachedData[matchingCachedDataIndex].datapoints = _.takeRight(datapoints, 800);
+      cachedData[matchingCachedDataIndex].target = deltaData.target;
     } else {
-      cachedData.push(deltaData);
-    }
-  });
+        cachedData.push(deltaData);
+      }
+    });
+
   return cachedData;
 }


### PR DESCRIPTION
When we cache requests, we later on append new data to them without filtering out data which is not within the selected time frame. That is usually not an issue since overflowing datapoints get cropped out automatically. However, some visualization panels do not do that (e.g., singlestat). Additionally, it is always possible to select "Query inspector" > "Data" tab and see ALL datapoints. That is quite misleading when a user first selects a time frame of let's say one hour and afterwards only five minutes. The data will be fetched from our cached and while we do not visually show all of it, the "Data" tab within the query inspector will still show all datapoints of the last one hour.

**What does this PR do?**
Before displaying data, remove all datapoints that correspond to a timestamp before `timeFilter.from` in order to avoid showing too many datapoints in the "Data" panel.