### PR TITLE
Add more operators for TagFilters and tests

### DIFF
--- a/src/components/Analyze/Filter.test.ts
+++ b/src/components/Analyze/Filter.test.ts
@@ -1,4 +1,5 @@
 import { InstanaQuery } from '../../types/instana_query';
+import Operators from '../../lists/operators';
 import TagFilter from '../../types/tag_filter';
 import { Filters } from './Filter';
 
@@ -413,6 +414,144 @@ describe('Given a filter', () => {
 
         const show = filters.canShowStringInput(filter);
 
+        expect(show).toEqual(false);
+      });
+    });
+  });
+
+  describe('for canShowNumberInput', () => {
+    let typeUnderTest = 'NUMBER';
+    describe('with any type except NUMBER', () => {
+      it('should not show input for any operator at all', () => {
+        Operators.forEach((element: any) => {
+          if (element.type !== typeUnderTest) {
+            let filter: TagFilter = {
+              tag: { key: 'any.key', type: element.type },
+              operator: { key: element.key, type: element.type },
+              stringValue: '',
+              numberValue: 0,
+              booleanValue: false,
+              isValid: false,
+              entity: '',
+            };
+
+            const show = filters.canShowNumberInput(filter);
+            expect(show).toEqual(false);
+          }
+        });
+      });
+    });
+
+    describe('with NUMBER type', () => {
+      it('should show input for any EQUALS', () => {
+        let filter: TagFilter = {
+          tag: { key: 'any.key', type: typeUnderTest },
+          operator: { key: 'EQUALS', type: typeUnderTest },
+          stringValue: '',
+          numberValue: 0,
+          booleanValue: false,
+          isValid: false,
+          entity: '',
+        }
+        const show = filters.canShowNumberInput(filter);
+        expect(show).toEqual(true);
+      });
+
+      it('should show input for any NOT_EQUAL', () => {
+        let filter: TagFilter = {
+          tag: { key: 'any.key', type: typeUnderTest },
+          operator: { key: 'NOT_EQUAL', type: typeUnderTest },
+          stringValue: '',
+          numberValue: 0,
+          booleanValue: false,
+          isValid: false,
+          entity: '',
+        }
+        const show = filters.canShowNumberInput(filter);
+        expect(show).toEqual(true);
+      });
+
+      it('should show input for any LESS_THAN', () => {
+        let filter: TagFilter = {
+          tag: { key: 'any.key', type: typeUnderTest },
+          operator: { key: 'LESS_THAN', type: typeUnderTest },
+          stringValue: '',
+          numberValue: 0,
+          booleanValue: false,
+          isValid: false,
+          entity: '',
+        }
+        const show = filters.canShowNumberInput(filter);
+        expect(show).toEqual(true);
+      });
+
+      it('should show input for any GREATER_THAN', () => {
+        let filter: TagFilter = {
+          tag: { key: 'any.key', type: typeUnderTest },
+          operator: { key: 'GREATER_THAN', type: typeUnderTest },
+          stringValue: '',
+          numberValue: 0,
+          booleanValue: false,
+          isValid: false,
+          entity: '',
+        }
+        const show = filters.canShowNumberInput(filter);
+        expect(show).toEqual(true);
+      });
+
+      it('should show input for any LESS_OR_EQUAL_THAN', () => {
+        let filter: TagFilter = {
+          tag: { key: 'any.key', type: typeUnderTest },
+          operator: { key: 'LESS_OR_EQUAL_THAN', type: typeUnderTest },
+          stringValue: '',
+          numberValue: 0,
+          booleanValue: false,
+          isValid: false,
+          entity: '',
+        }
+        const show = filters.canShowNumberInput(filter);
+        expect(show).toEqual(true);
+      });
+
+      it('should show input for any GREATER_OR_EQUAL_THAN', () => {
+        let filter: TagFilter = {
+          tag: { key: 'any.key', type: typeUnderTest },
+          operator: { key: 'GREATER_OR_EQUAL_THAN', type: typeUnderTest },
+          stringValue: '',
+          numberValue: 0,
+          booleanValue: false,
+          isValid: false,
+          entity: '',
+        }
+        const show = filters.canShowNumberInput(filter);
+        expect(show).toEqual(true);
+      });
+
+      it('should show input for any NOT_EMPTY', () => {
+        let filter: TagFilter = {
+          tag: { key: 'any.key', type: typeUnderTest },
+          operator: { key: 'NOT_EMPTY', type: typeUnderTest },
+          stringValue: '',
+          numberValue: 0,
+          booleanValue: false,
+          isValid: false,
+          entity: '',
+        }
+        const show = filters.canShowNumberInput(filter);
+        expect(show).toEqual(false);
+      });
+
+      it('should show input for any IS_EMPTY', () => {
+        let filter: TagFilter = {
+          tag: { key: 'any.key', type: typeUnderTest },
+          operator: { key: 'IS_EMPTY', type: typeUnderTest },
+          stringValue: '',
+          numberValue: 0,
+          booleanValue: false,
+          isValid: false,
+          entity: '',
+        }
+        const show = filters.canShowNumberInput(filter);
         expect(show).toEqual(false);
       });
     });

--- a/src/components/Analyze/Filter.tsx
+++ b/src/components/Analyze/Filter.tsx
@@ -95,6 +95,10 @@ export class Filters extends React.Component<Props, FilterState> {
     );
   }
 
+  canShowNumberInput(filter: TagFilter) {
+    return filter.tag.type === this.OPERATOR_NUMBER && !filter.operator.key.includes('EMPTY');
+  }
+
   debouncedRunQuery = _.debounce(this.props.onRunQuery, 500);
 
   onTagFilterStringValueChange = (value: FormEvent<HTMLInputElement>, index: number) => {
@@ -195,7 +199,7 @@ export class Filters extends React.Component<Props, FilterState> {
           />
           <Select
             menuPlacement={'bottom'}
-            width={12}
+            width={20}
             isSearchable={true}
             value={query.filters[index].operator}
             options={this.filterOperatorsOnType(query.filters[index].tag.type)}
@@ -212,7 +216,7 @@ export class Filters extends React.Component<Props, FilterState> {
             />
           )}
 
-          {query.filters[index].tag.type === 'NUMBER' && (
+          {this.canShowNumberInput(query.filters[index]) && (
             <Input
               css={''}
               type={'number'}

--- a/src/lists/operators.ts
+++ b/src/lists/operators.ts
@@ -6,12 +6,19 @@ export default [
   { key: 'NOT_CONTAIN', label: 'does not contain', type: 'STRING' },
   { key: 'NOT_EMPTY', label: 'is present', type: 'STRING' },
   { key: 'IS_EMPTY', label: 'is not present', type: 'STRING' },
+  { key: 'STARTS_WITH', label: 'starts with', type: 'STRING' },
+  { key: 'ENDS_WITH', label: 'ends with', type: 'STRING' },
+  { key: 'NOT_STARTS_WITH', label: 'does not start with', type: 'STRING' },
+  { key: 'NOT_ENDS_WITH', label: 'does not end with', type: 'STRING' },
   // NUMBER
   { key: 'EQUALS', label: '=', type: 'NUMBER' },
   { key: 'NOT_EQUAL', label: '!=', type: 'NUMBER' },
   { key: 'LESS_THAN', label: '<', type: 'NUMBER' },
   { key: 'GREATER_THAN', label: '>', type: 'NUMBER' },
   { key: 'IS_EMPTY', label: 'is empty', type: 'NUMBER' },
+  { key: 'NOT_EMPTY', label: 'is not empty', type: 'NUMBER' },
+  { key: 'LESS_OR_EQUAL_THAN', label: 'less or equal than', type: 'NUMBER' },
+  { key: 'GREATER_OR_EQUAL_THAN', label: 'greater or equal than', type: 'NUMBER' },
   // BOOLEAN
   { key: 'EQUALS', label: 'is', type: 'BOOLEAN' },
   // KEY_VALUE_PAIR
@@ -21,6 +28,10 @@ export default [
   { key: 'NOT_CONTAIN', label: 'does not contain', type: 'KEY_VALUE_PAIR' },
   { key: 'NOT_EMPTY', label: 'is present', type: 'KEY_VALUE_PAIR' },
   { key: 'IS_EMPTY', label: 'is not present', type: 'KEY_VALUE_PAIR' },
+  { key: 'STARTS_WITH', label: 'starts with', type: 'KEY_VALUE_PAIR' },
+  { key: 'ENDS_WITH', label: 'ends with', type: 'KEY_VALUE_PAIR' },
+  { key: 'IS_BLANK', label: 'is blank', type: 'KEY_VALUE_PAIR' },
+  { key: 'NOT_BLANK', label: 'is not blank', type: 'KEY_VALUE_PAIR' },
   // STRING_SET
   { key: 'EQUALS', label: 'equals', type: 'STRING_SET' },
   { key: 'NOT_EQUAL', label: 'does not equal', type: 'STRING_SET' },


### PR DESCRIPTION
For feature parity with the Instana UI. Adds following new operators: 

## For Strings: 

`STARTS_WITH`
`ENDS_WITH`
`NOT_STARTS_WITH`
`NOT_ENDS_WITH`

## For Numbers: 

`NOT_EMPTY`
`LESS_OR_EQUAL_THAN`
`GREATER_OR_EQUAL_THAN`

## For Key Value Pairs: 

`STARTS_WITH`
`ENDS_WITH`
`IS_BLANK`
`NOT_BLANK`