### PR TITLE
Mark objects as optional to avoid throwing exceptions

### DIFF
--- a/src/components/Analyze/Filter.tsx
+++ b/src/components/Analyze/Filter.tsx
@@ -177,7 +177,7 @@ export class Filters extends React.Component<Props, FilterState> {
   render() {
     const { query, groups } = this.props;
 
-    let listFilter = query.filters.map((singleFilter, index) => {
+    let listFilter = query.filters?.map((singleFilter, index) => {
       return (
         <div className={'gf-form'}>
           <InlineFormLabel className={'query-keyword'} width={14} tooltip={'Filter by tag.'}>

--- a/src/components/ApplicationServiceEndpointMetrics/ApplicationServiceEndpointMetrics.tsx
+++ b/src/components/ApplicationServiceEndpointMetrics/ApplicationServiceEndpointMetrics.tsx
@@ -211,7 +211,7 @@ export class ApplicationServiceEndpointMetrics extends React.Component<Props, Ap
         </InlineFormLabel>
         <ApplicationBoundaryScope
           value={query.applicationBoundaryScope}
-          disabled={!query.entity.key}
+          disabled={!query.entity?.key}
           onChange={this.onApplicationBoundaryScopeChange}
         />
         <Select


### PR DESCRIPTION
When we create a new query in the usual "Dashboard" section, we set some default values. However, these default values are not set when using the "Explore" section within Grafana (I guess because of some Grafana internal magic).

This fix sets two values as optional to avoid throwing exceptions and blocking the Explore view.