### PR TITLE
align to and window size to granularity

### DIFF
--- a/src/datasources/DataSource_Service.ts
+++ b/src/datasources/DataSource_Service.ts
@@ -3,7 +3,7 @@ import { InstanaOptions } from '../types/instana_options';
 import Cache from '../cache';
 import _ from 'lodash';
 import TimeFilter from '../types/time_filter';
-import { getTimeKey, getWindowSize } from '../util/time_util';
+import { getTimeKey, getWindowSize, floorToGranularity, ceilToGranularity } from '../util/time_util';
 import { getRequest, postRequest } from '../util/request_handler';
 import { getDefaultChartGranularity } from '../util/rollup_granularity_util';
 import { InstanaQuery } from '../types/instana_query';
@@ -132,8 +132,8 @@ export class DataSourceService {
 
     const data: any = {
       timeFrame: {
-        to: timeFilter.to,
-        windowSize: windowSize,
+        to: floorToGranularity(timeFilter.to, metric.granularity),
+        windowSize: ceilToGranularity(windowSize, metric.granularity),
       },
       metrics: [metric],
     };

--- a/src/datasources/DataSource_Website.ts
+++ b/src/datasources/DataSource_Website.ts
@@ -3,7 +3,7 @@ import { InstanaOptions } from '../types/instana_options';
 import Cache from '../cache';
 import _ from 'lodash';
 import TimeFilter from '../types/time_filter';
-import { getTimeKey, getWindowSize, hoursToMs } from '../util/time_util';
+import { getTimeKey, getWindowSize, hoursToMs, floorToGranularity, ceilToGranularity } from '../util/time_util';
 import BeaconGroupBody from '../types/beacon_group_body';
 import { getRequest, postRequest } from '../util/request_handler';
 import { getDefaultChartGranularity } from '../util/rollup_granularity_util';
@@ -146,15 +146,15 @@ export class DataSourceWebsite {
         tagFilters.push(createTagFilter(filter));
       }
     });
-    const metric: any = {
-      metric: target.metric.key,
-      aggregation: target.aggregation.key ? target.aggregation.key : 'SUM',
-    };
 
     if (!target.timeInterval) {
       target.timeInterval = getDefaultChartGranularity(windowSize);
     }
-    metric['granularity'] = target.timeInterval.key;
+    const metric: any = {
+      metric: target.metric.key,
+      aggregation: target.aggregation.key ? target.aggregation.key : 'SUM',
+      granularity: target.timeInterval.key,
+    };
 
     const group: any = {
       groupbyTag: target.group.key,
@@ -166,8 +166,8 @@ export class DataSourceWebsite {
     const data: BeaconGroupBody = {
       group: group,
       timeFrame: {
-        to: timeFilter.to,
-        windowSize: windowSize,
+        to: floorToGranularity(timeFilter.to, metric.granularity),
+        windowSize: ceilToGranularity(windowSize, metric.granularity),
       },
       tagFilters: tagFilters,
       type: target.entityType.key,

--- a/src/util/time_util.ts
+++ b/src/util/time_util.ts
@@ -31,3 +31,13 @@ export function hoursToMs(hours: any): number {
   }
   return 0;
 }
+
+export function floorToGranularity(millis: number, granularity: number): number {
+  const granularityInMs = granularity * 1000;
+  return Math.floor(millis / granularityInMs) * granularityInMs;
+}
+
+export function ceilToGranularity(millis: number, granularity: number): number {
+  const granularityInMs = granularity * 1000;
+  return Math.ceil(millis / granularityInMs) * granularityInMs;
+}


### PR DESCRIPTION
# why
Sometimes calculated window size for delta requests is covering a short time and gets rejected by our backend.

# what
Adjust send `to` and `windowSize` to granularity, as `AdjustedMetricsTimeframe` is also doing.