### PR TITLE
Infra Analyze Open Beta

### DIFF
--- a/grafana.ini
+++ b/grafana.ini
@@ -764,7 +764,7 @@ app_mode = development
 #################################### Explore #############################
 [explore]
 # Enable the Explore section
-;enabled = true
+enabled = true
 
 #################################### Internal Grafana Metrics ##########################
 # Metrics available at HTTP API Url /metrics

--- a/specs/mb/imposters/calls_infrastructure.ejs
+++ b/specs/mb/imposters/calls_infrastructure.ejs
@@ -315,7 +315,7 @@
   "predicates": [{
     "equals": {
       "method": "POST",
-      "path": "/api/infrastructure-monitoring/explore/groups"
+      "path": "/api/infrastructure-monitoring/analyze/entity-groups"
     }
   },{
     "contains": { "body": "tagFilterExpression" }

--- a/specs/mb/imposters/infraExplore_response.ejs
+++ b/specs/mb/imposters/infraExplore_response.ejs
@@ -21,48 +21,40 @@ function (request, state, logger) {
     },
     body: JSON.stringify(
       {
-        "data": {
-          "items": [
-            {
-              "tags": {
-                "kubernetes.namespace.name": "You"
-              },
-              "count": 2,
-              "metrics": {
-                "cpu.total_usage.P99": datapoints1
-              }
+        "items": [
+          {
+            "tags": {
+              "kubernetes.namespace.name": "You"
             },
-            {
-              "tags": {
-                "kubernetes.namespace.name": "are"
-              },
-              "count": 1,
-              "metrics": {
-                "cpu.total_usage.P99": datapoints2
-              }
-            },
-            {
-              "tags": {
-                "kubernetes.namespace.name": "awesome"
-              },
-              "count": 6,
-              "metrics": {
-                "cpu.total_usage.P99": datapoints3
-              }
+            "count": 2,
+            "metrics": {
+              "cpu.total_usage.P99": datapoints1
             }
-          ],
-          "canLoadMore": false,
-          "totalHits": 6,
-          "totalRepresentedItemCount": 61,
-          "next": null
-        },
+          },
+          {
+            "tags": {
+              "kubernetes.namespace.name": "are"
+            },
+            "count": 1,
+            "metrics": {
+              "cpu.total_usage.P99": datapoints2
+            }
+          },
+          {
+            "tags": {
+              "kubernetes.namespace.name": "awesome"
+            },
+            "count": 6,
+            "metrics": {
+              "cpu.total_usage.P99": datapoints3
+            }
+          }
+        ],
+        "canLoadMore": false,
+        "totalHits": 6,
+        "totalRepresentedItemCount": 61,
+        "next": null
         "adjustedWindowSize": null,
-        "errors": [],
-        "progress": {
-          "percentage": null,
-          "loading": false,
-          "note": null
-        }
       }
     )
   };

--- a/src/datasources/Datasource_Infrastructure.ts
+++ b/src/datasources/Datasource_Infrastructure.ts
@@ -208,15 +208,15 @@ export class DataSourceInfrastructure {
       },
     };
 
-    return postRequest(this.instanaOptions, '/api/infrastructure-monitoring/explore/groups', payload).then(
+    return postRequest(this.instanaOptions, '/api/infrastructure-monitoring/analyze/entity-groups', payload).then(
       (res: any) => {
         let result: any = [];
 
-        if (!res.data.data && res.data.errors.length >= 1) {
-          throw new Error(res.data.errors[0].message || res.data.errors[0]);
+        if (!res.data && res.errors.length >= 1) {
+          throw new Error(res.errors[0].message || res.errors[0]);
         }
 
-        res.data.data.items.forEach((entity: any) => {
+        res.data.items.forEach((entity: any) => {
           for (var metric in entity.metrics) {
             result.push({
               target: entity.tags[data.groupBy] + ' - ' + metric,


### PR DESCRIPTION
#Why 

Infrastructure Analyze API update needs to be reflected in Grafana plugin.

## What

- update URL for Infrastructure Analyze (former one remains usable but deprecated)
- [ ] change name from Infra Explore to Infra Analyze
- [ ] make Infra Analyze accessible by default and not an option
- [ ] update doc and screenshots

