### PR TITLE
Adding missing includeSynthetic option in grafana CSP TS014371147

### DIFF
--- a/src/components/Analyze/Filter.tsx
+++ b/src/components/Analyze/Filter.tsx
@@ -233,8 +233,8 @@ export class Filters extends React.Component<Props, FilterState> {
               onChange={(e) => this.onTagFilterBooleanValueChange(e, index)}
               value={{ key: '' + query.filters[index].booleanValue, label: '' + query.filters[index].booleanValue }}
               options={[
-                { key: 'false', label: 'false' },
-                { key: 'true', label: 'true' },
+                { key: false, label: 'false' },
+                { key: true, label: 'true' },
               ]}
             />
           )}

--- a/src/datasources/DataSource_Application.ts
+++ b/src/datasources/DataSource_Application.ts
@@ -168,7 +168,7 @@ export class DataSourceApplication {
           value: target.entity.label!,
           entity: target.applicationCallToEntity ? target.applicationCallToEntity : 'DESTINATION',
         });
-      }
+        }
 
       _.forEach(target.filters, (filter) => {
         if (filter.isValid) {
@@ -201,6 +201,13 @@ export class DataSourceApplication {
         group['groupbyTagSecondLevelKey'] = target.groupbyTagSecondLevelKey;
       }
 
+      let includeSynthetic = false;
+      target.filters.map(filter => {
+        if(filter.tag.key==='call.is_synthetic') {
+        includeSynthetic = filter.booleanValue;
+       }
+      });
+
       const data: any = {
         group: group,
         timeFrame: {
@@ -208,6 +215,7 @@ export class DataSourceApplication {
           windowSize: atLeastGranularity(windowSize, metric.granularity),
         },
         metrics: [metric],
+        includeSynthetic,
         tagFilterExpression: {
           type: 'EXPRESSION',
           logicalOperator: 'AND',

--- a/src/util/analyze_util.ts
+++ b/src/util/analyze_util.ts
@@ -6,15 +6,15 @@ export function createTagFilter(filter: TagFilter) {
   let tagFilter = {
     name: filter.tag.key,
     operator: filter.operator.key,
-    value: filter.stringValue,
+    value: false,
   };
 
   if ('NUMBER' === filter.tag.type) {
     if (filter.numberValue !== null) {
-      tagFilter.value = filter.numberValue.toString();
+      tagFilter.value = filter.numberValue !== 0;
     }
   } else if ('BOOLEAN' === filter.tag.type) {
-    tagFilter.value = filter.booleanValue.toString();
+    tagFilter.value = filter.booleanValue;
   }
 
   return tagFilter;


### PR DESCRIPTION
> ### Why?

In Grafana dashboard as there is no difference between filter `Call.Is Synthetic=true` and `Call.Is Synthetic=false` options and also `includeSynthetic: true/false option`  is missing  for synthetic calls. 

> ### What?

- `includeSynthetic` option enabled and fix the issue for filter ` Call.Is Synthetic=true/false` 

>  **link to cards**: https://instana.kanbanize.com/ctrl_board/206/cards/144323/details/

