### PR TITLE
Add filter button for analyze mobile app metrics data

### DIFF
--- a/src/components/Analyze/Filter.tsx
+++ b/src/components/Analyze/Filter.tsx
@@ -1,6 +1,6 @@
 import React, { FormEvent } from 'react';
 
-import { ANALYZE_APPLICATION_METRICS, PLEASE_SPECIFY } from '../../GlobalVariables';
+import { ANALYZE_APPLICATION_METRICS,ANALYZE_MOBILE_APP_METRICS, PLEASE_SPECIFY } from '../../GlobalVariables';
 import { Button, InlineFormLabel, Input, Select } from '@grafana/ui';
 import call_to_entities from '../../lists/apply_call_to_entities';
 import { DataSource } from '../../datasources/DataSource';
@@ -183,7 +183,7 @@ export class Filters extends React.Component<Props, FilterState> {
           <InlineFormLabel className={'query-keyword'} width={14} tooltip={'Filter by tag.'}>
             {index + 1}. filter
           </InlineFormLabel>
-          {query.metricCategory.key === ANALYZE_APPLICATION_METRICS && (
+          {query.metricCategory.key === ANALYZE_APPLICATION_METRICS && ANALYZE_MOBILE_APP_METRICS && (
             <Entity
               value={query.filters[index].entity}
               onChange={(callToEntity: string) => this.onCallToEntityChange(callToEntity, index)}

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -501,7 +501,8 @@ export class QueryEditor extends PureComponent<Props, QueryState> {
         )}
 
         {(query.metricCategory.key === ANALYZE_APPLICATION_METRICS ||
-          query.metricCategory.key === ANALYZE_WEBSITE_METRICS) && (
+          query.metricCategory.key === ANALYZE_WEBSITE_METRICS ||
+          query.metricCategory.key === ANALYZE_MOBILE_APP_METRICS) && (
           <Filters
             query={query}
             onChange={this.props.onChange}


### PR DESCRIPTION
> ### Why?

In Grafana dashboard as there is no Add **filter**  button for **Analyze mobile app** metrics data in grafana UI
> ### What?

- Add filter button for analyze mobile app metrics data in grafana UI.

>  **link to cards**: https://instana.kanbanize.com/ctrl_board/206/cards/140770/details/

> ### Screenshots

- **Before**

<img width="1725" alt="Screenshot 2023-11-02 at 3 49 29 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/ff05285c-a49d-4d59-8400-524e3bcc8afd">
<img width="1728" alt="Screenshot 2023-11-02 at 3 49 56 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/d760e4ec-c49d-41c9-bf70-abb463f29480">



- **After**


<img width="1727" alt="Screenshot 2023-11-02 at 3 31 40 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/5f3f102a-0b67-46e0-9f66-4463afd2a6c7">
<img width="1728" alt="Screenshot 2023-11-02 at 3 30 07 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/2bc76d74-a87d-4c39-aa91-beff869798a8">
<img width="1728" alt="Screenshot 2023-11-02 at 3 32 58 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/fb829f1e-704e-4f1b-9910-28d12c8c7c18">






