### PR TITLE
Infra analyze updation

### DIFF
--- a/src/components/Analyze/ApplicationCallsMetrics.tsx
+++ b/src/components/Analyze/ApplicationCallsMetrics.tsx
@@ -45,9 +45,8 @@ export class ApplicationCallsMetrics extends React.Component<Props, ApplicationC
     const { query, datasource, onChange } = this.props;
     isUnmounting = false;
     datasource.fetchApplications().then((applications) => {
-      console.log(applications,"app");
       
-      if (!isUnmounting) {
+    if (!isUnmounting) {
         if (!_.find(applications, { key: null })) {
           applications.unshift({ key: null, label: ALL_APPLICATIONS });
         }

--- a/src/components/Analyze/ApplicationCallsMetrics.tsx
+++ b/src/components/Analyze/ApplicationCallsMetrics.tsx
@@ -45,6 +45,8 @@ export class ApplicationCallsMetrics extends React.Component<Props, ApplicationC
     const { query, datasource, onChange } = this.props;
     isUnmounting = false;
     datasource.fetchApplications().then((applications) => {
+      console.log(applications,"app");
+      
       if (!isUnmounting) {
         if (!_.find(applications, { key: null })) {
           applications.unshift({ key: null, label: ALL_APPLICATIONS });

--- a/src/components/Analyze/ApplicationCallsMetrics.tsx
+++ b/src/components/Analyze/ApplicationCallsMetrics.tsx
@@ -45,8 +45,7 @@ export class ApplicationCallsMetrics extends React.Component<Props, ApplicationC
     const { query, datasource, onChange } = this.props;
     isUnmounting = false;
     datasource.fetchApplications().then((applications) => {
-      
-    if (!isUnmounting) {
+      if (!isUnmounting) {
         if (!_.find(applications, { key: null })) {
           applications.unshift({ key: null, label: ALL_APPLICATIONS });
         }

--- a/src/components/Infrastructure/Explore.tsx
+++ b/src/components/Infrastructure/Explore.tsx
@@ -1,38 +1,26 @@
-import React, { ChangeEvent } from 'react';
-
-import { PLEASE_SPECIFY, INFRASTRUCTURE_ANALYZE } from '../../GlobalVariables';
-import call_to_entities from '../../lists/apply_call_to_entities';
-import { Input, Select, InlineFormLabel } from '@grafana/ui';
-import { DataSource } from '../../datasources/DataSource';
-import { InstanaQuery } from '../../types/instana_query';
-import FormWrapper from '../FormField/FormWrapper';
-import { SelectableValue } from '@grafana/data';
-import Entity from '../Entity/Entity';
-import _ from 'lodash';
 import '../plugin.css';
-
+import { InlineFormLabel, Input, Select } from '@grafana/ui';
+import React, { ChangeEvent } from 'react';
+import { DataSource } from '../../datasources/DataSource';
+import FormWrapper from '../FormField/FormWrapper';
+import { InstanaQuery } from '../../types/instana_query';
+import { PLEASE_SPECIFY } from '../../GlobalVariables';
+import { SelectableValue } from '@grafana/data';
+import _ from 'lodash';
+import call_to_entities from '../../lists/apply_call_to_entities';
 interface AnalyzeState {
   entityTypes: SelectableValue[];
 }
-
 interface Props {
   query: InstanaQuery;
-
   groups: SelectableValue[];
-
   updateGroups(groups: SelectableValue[]): void;
-
   onRunQuery(): void;
-
   onChange(value: InstanaQuery): void;
-
-  updateMetrics(metrics: SelectableValue[]): void;
-
+  updateMetrics(metrics: any): void;
   datasource: DataSource;
 }
-
 let isUnmounting = false;
-
 export class Explore extends React.Component<Props, AnalyzeState> {
   constructor(props: any) {
     super(props);
@@ -40,147 +28,97 @@ export class Explore extends React.Component<Props, AnalyzeState> {
       entityTypes: [],
     };
   }
-
   componentDidMount() {
     const { query, datasource, onChange } = this.props;
     isUnmounting = false;
-    datasource.fetchTypesForTarget(query).then((entityTypes:SelectableValue[]) => {
-      // datasource.getEntityTypes().then((entityTypes: any) => {
-      console.log(entityTypes, 'entitytype');
-      console.log(query, 'query');
+    datasource.getEntityTypes().then((entityTypes:SelectableValue[]) => {
 
       if (!isUnmounting) {
         if (!_.find(entityTypes, { key: null })) {
           entityTypes.unshift({ key: null, label: PLEASE_SPECIFY });
         }
-        // console.log(datasource.getEntityTypes, 'getEntityTypes');
-
         this.setState({
           entityTypes: entityTypes,
         });
-        console.log(query, 'query');
-
         if (!query.entity || (!query.entity.key && !query.entity.label)) {
           query.entity = entityTypes[0];
         }
-
         if (!query.callToEntity) {
           query.callToEntity = call_to_entities[0];
         }
         if (!query.applicationCallToEntity) {
           query.applicationCallToEntity = call_to_entities[0];
         }
-
         onChange(query);
       }
     });
 
-    datasource.fetchAnalyzetages().then((applicationTags: any) => {
-      if (!isUnmounting) {
-        this.props.updateGroups(_.sortBy(applicationTags, 'key'));
-
-        // select a meaningful default group
-        if (!query.group || !query.group.key) {
-          query.group = _.find(applicationTags, ['key', 'endpoint.name']);
-          onChange(query);
-        }
-      }
-    });
-
-    this.props.updateMetrics(datasource.dataSourceInfrastructure.getAnalyzeMetricsCatalog());
   }
-
   componentWillUnmount() {
     isUnmounting = true;
   }
-
-  onApplicationChange = (entityTypes: SelectableValue) => {
-    const { query, onChange, onRunQuery } = this.props;
-    query.entity = entityTypes;
+  onEntityChange = (entityType: SelectableValue) => {
+    const { query, datasource,onChange, onRunQuery } = this.props;
+    query.entity = entityType;
     onChange(query);
     onRunQuery();
+    datasource.dataSourceInfrastructure.getAnalyzeMetricsCatalog(query).then((result: any) => {
+      this.props.updateMetrics(result);
+    });
   };
-
-  onGroupChange = (group: SelectableValue) => {
-    const { query, onChange, onRunQuery } = this.props;
-    query.group = group;
-
-    if (query.group && query.metricCategory.key === INFRASTRUCTURE_ANALYZE) {
-      query.showGroupBySecondLevel = query.group.type === 'KEY_VALUE_PAIR';
-    }
-
-    if (!query.showGroupBySecondLevel) {
-      query.groupbyTagSecondLevelKey = '';
-    }
-
-    onChange(query);
-    onRunQuery();
-  };
-
-  onApplicationCallToEntityChange = (applicationCallToEntity: string) => {
+  onInfraCallToEntityChange = (applicationCallToEntity: string) => {
     const { query, onChange, onRunQuery } = this.props;
     query.applicationCallToEntity = applicationCallToEntity;
     onChange(query);
     onRunQuery();
   };
-
-  onCallToEntityChange = (callToEntity: string) => {
-    const { query, onChange, onRunQuery } = this.props;
-    query.callToEntity = callToEntity;
-    onChange(query);
-    onRunQuery();
-  };
-
   debouncedRunQuery = _.debounce(this.props.onRunQuery, 500);
-
+  onCallToEntityChange = (eventItem: ChangeEvent<HTMLInputElement>) => {
+    const { query, onChange } = this.props;
+    query.callToEntity = eventItem.currentTarget.value;
+    onChange(query);
+    // onRunQuery with 500ms delay after last debounce
+    this.debouncedRunQuery();
+  }
   onGroupByTagSecondLevelKeyChange = (eventItem: ChangeEvent<HTMLInputElement>) => {
     const { query, onChange } = this.props;
+    query.group = { 
+      key: eventItem.currentTarget.value,
+      label: eventItem.currentTarget.value,
+      type: 'STRING',
+    }
     query.groupbyTagSecondLevelKey = eventItem.currentTarget.value;
     onChange(query);
-
     // onRunQuery with 500ms delay after last debounce
     this.debouncedRunQuery();
   };
-
   render() {
     const { query } = this.props;
-
     return (
       <div className={'gf-form'}>
         <FormWrapper stretch={true}>
-          <InlineFormLabel className={'query-keyword'} width={14} tooltip={'Select your Entity.'}>
+          <InlineFormLabel className={'query-keyword'} width={14} tooltip={'Select your Entity Type.'}>
             Entity types
           </InlineFormLabel>
-          <Entity value={query.applicationCallToEntity} onChange={this.onApplicationCallToEntityChange} />
           <Select
             menuPlacement={'bottom'}
             width={0}
             isSearchable={true}
             value={query.entity}
             options={this.state.entityTypes}
-            onChange={this.onApplicationChange}
+            onChange={this.onEntityChange}
           />
         </FormWrapper>
-
         <FormWrapper stretch={true}>
-          <InlineFormLabel className={'query-keyword'} width={7} tooltip={'Group by tag.'}>
+          <InlineFormLabel className={'query-keyword'} width={7} tooltip={'Enter the Group by tag.'}>
             Group by
           </InlineFormLabel>
-          <Entity value={query.callToEntity} onChange={this.onCallToEntityChange} />
           <Input
             type={'text'}
             value={query.groupbyTagSecondLevelKey}
             onChange={this.onGroupByTagSecondLevelKeyChange}
           />
         </FormWrapper>
-
-        <div style={!query.showGroupBySecondLevel ? { display: 'none' } : {}}>
-          <Input
-            type={'text'}
-            value={query.groupbyTagSecondLevelKey}
-            onChange={this.onGroupByTagSecondLevelKeyChange}
-          />
-        </div>
       </div>
     );
   }

--- a/src/components/Infrastructure/Explore.tsx
+++ b/src/components/Infrastructure/Explore.tsx
@@ -1,72 +1,184 @@
 import React, { ChangeEvent } from 'react';
 
-import FormTextArea from 'components/FormField/FormTextArea';
+import { PLEASE_SPECIFY, INFRASTRUCTURE_ANALYZE } from '../../GlobalVariables';
+import call_to_entities from '../../lists/apply_call_to_entities';
+import { Input, Select, InlineFormLabel } from '@grafana/ui';
 import { DataSource } from '../../datasources/DataSource';
 import { InstanaQuery } from '../../types/instana_query';
+import FormWrapper from '../FormField/FormWrapper';
 import { SelectableValue } from '@grafana/data';
+import Entity from '../Entity/Entity';
 import _ from 'lodash';
 import '../plugin.css';
 
-interface State {
-  queryTypes: SelectableValue[];
+interface AnalyzeState {
+  entityTypes: SelectableValue[];
 }
 
 interface Props {
   query: InstanaQuery;
-  datasource: DataSource;
-  queryTypes: SelectableValue[];
+
+  groups: SelectableValue[];
+
+  updateGroups(groups: SelectableValue[]): void;
+
   onRunQuery(): void;
+
   onChange(value: InstanaQuery): void;
+
   updateMetrics(metrics: SelectableValue[]): void;
-  updateQueryTypes(types: SelectableValue[]): void;
+
+  datasource: DataSource;
 }
 
-export class Explore extends React.Component<Props, State> {
+let isUnmounting = false;
+
+export class Explore extends React.Component<Props, AnalyzeState> {
   constructor(props: any) {
     super(props);
+    this.state = {
+      entityTypes: [],
+    };
   }
 
-  onFilterChange = (eventItem: ChangeEvent<HTMLInputElement>) => {
+  componentDidMount() {
+    const { query, datasource, onChange } = this.props;
+    isUnmounting = false;
+    datasource.fetchTypesForTarget(query).then((entityTypes:SelectableValue[]) => {
+      // datasource.getEntityTypes().then((entityTypes: any) => {
+      console.log(entityTypes, 'entitytype');
+      console.log(query, 'query');
+
+      if (!isUnmounting) {
+        if (!_.find(entityTypes, { key: null })) {
+          entityTypes.unshift({ key: null, label: PLEASE_SPECIFY });
+        }
+        // console.log(datasource.getEntityTypes, 'getEntityTypes');
+
+        this.setState({
+          entityTypes: entityTypes,
+        });
+        console.log(query, 'query');
+
+        if (!query.entity || (!query.entity.key && !query.entity.label)) {
+          query.entity = entityTypes[0];
+        }
+
+        if (!query.callToEntity) {
+          query.callToEntity = call_to_entities[0];
+        }
+        if (!query.applicationCallToEntity) {
+          query.applicationCallToEntity = call_to_entities[0];
+        }
+
+        onChange(query);
+      }
+    });
+
+    datasource.fetchAnalyzetages().then((applicationTags: any) => {
+      if (!isUnmounting) {
+        this.props.updateGroups(_.sortBy(applicationTags, 'key'));
+
+        // select a meaningful default group
+        if (!query.group || !query.group.key) {
+          query.group = _.find(applicationTags, ['key', 'endpoint.name']);
+          onChange(query);
+        }
+      }
+    });
+
+    this.props.updateMetrics(datasource.dataSourceInfrastructure.getAnalyzeMetricsCatalog());
+  }
+
+  componentWillUnmount() {
+    isUnmounting = true;
+  }
+
+  onApplicationChange = (entityTypes: SelectableValue) => {
+    const { query, onChange, onRunQuery } = this.props;
+    query.entity = entityTypes;
+    onChange(query);
+    onRunQuery();
+  };
+
+  onGroupChange = (group: SelectableValue) => {
+    const { query, onChange, onRunQuery } = this.props;
+    query.group = group;
+
+    if (query.group && query.metricCategory.key === INFRASTRUCTURE_ANALYZE) {
+      query.showGroupBySecondLevel = query.group.type === 'KEY_VALUE_PAIR';
+    }
+
+    if (!query.showGroupBySecondLevel) {
+      query.groupbyTagSecondLevelKey = '';
+    }
+
+    onChange(query);
+    onRunQuery();
+  };
+
+  onApplicationCallToEntityChange = (applicationCallToEntity: string) => {
+    const { query, onChange, onRunQuery } = this.props;
+    query.applicationCallToEntity = applicationCallToEntity;
+    onChange(query);
+    onRunQuery();
+  };
+
+  onCallToEntityChange = (callToEntity: string) => {
+    const { query, onChange, onRunQuery } = this.props;
+    query.callToEntity = callToEntity;
+    onChange(query);
+    onRunQuery();
+  };
+
+  debouncedRunQuery = _.debounce(this.props.onRunQuery, 500);
+
+  onGroupByTagSecondLevelKeyChange = (eventItem: ChangeEvent<HTMLInputElement>) => {
     const { query, onChange } = this.props;
-    query.tagFilterExpression = eventItem.currentTarget.value;
+    query.groupbyTagSecondLevelKey = eventItem.currentTarget.value;
     onChange(query);
 
     // onRunQuery with 500ms delay after last debounce
     this.debouncedRunQuery();
   };
 
-  isValidJson = (tagFilterExpression: string): boolean => {
-    if (tagFilterExpression) {
-      try {
-        JSON.parse(tagFilterExpression);
-        return true;
-      } catch (error) {
-        return false;
-      }
-    }
-
-    // no need to invalidate an empty input field
-    return true;
-  };
-
-  debouncedRunQuery = _.debounce(this.props.onRunQuery, 500);
-
   render() {
     const { query } = this.props;
 
     return (
-      <div>
-        <div className={'gf-form'}>
-          <FormTextArea
-            queryKeyword
-            inputWidth={0}
-            label={'Filter'}
-            tooltip={
-              'This is currently a beta feature and only available for selected customers. If you are interestedin this technology, please submit a request via our support system at https://support.instana.com/.'
-            }
-            value={query.tagFilterExpression}
-            invalid={!this.isValidJson(query.tagFilterExpression)}
-            onChange={this.onFilterChange}
+      <div className={'gf-form'}>
+        <FormWrapper stretch={true}>
+          <InlineFormLabel className={'query-keyword'} width={14} tooltip={'Select your Entity.'}>
+            Entity types
+          </InlineFormLabel>
+          <Entity value={query.applicationCallToEntity} onChange={this.onApplicationCallToEntityChange} />
+          <Select
+            menuPlacement={'bottom'}
+            width={0}
+            isSearchable={true}
+            value={query.entity}
+            options={this.state.entityTypes}
+            onChange={this.onApplicationChange}
+          />
+        </FormWrapper>
+
+        <FormWrapper stretch={true}>
+          <InlineFormLabel className={'query-keyword'} width={7} tooltip={'Group by tag.'}>
+            Group by
+          </InlineFormLabel>
+          <Entity value={query.callToEntity} onChange={this.onCallToEntityChange} />
+          <Input
+            type={'text'}
+            value={query.groupbyTagSecondLevelKey}
+            onChange={this.onGroupByTagSecondLevelKeyChange}
+          />
+        </FormWrapper>
+
+        <div style={!query.showGroupBySecondLevel ? { display: 'none' } : {}}>
+          <Input
+            type={'text'}
+            value={query.groupbyTagSecondLevelKey}
+            onChange={this.onGroupByTagSecondLevelKeyChange}
           />
         </div>
       </div>

--- a/src/components/Infrastructure/Explore.tsx
+++ b/src/components/Infrastructure/Explore.tsx
@@ -8,6 +8,7 @@ import { PLEASE_SPECIFY } from '../../GlobalVariables';
 import { SelectableValue } from '@grafana/data';
 import _ from 'lodash';
 import call_to_entities from '../../lists/apply_call_to_entities';
+
 interface AnalyzeState {
   entityTypes: SelectableValue[];
 }
@@ -62,7 +63,7 @@ export class Explore extends React.Component<Props, AnalyzeState> {
     query.entity = entityType;
     onChange(query);
     onRunQuery();
-    datasource.dataSourceInfrastructure.getAnalyzeMetricsCatalog(query).then((result: any) => {
+    datasource.fetchMetricsForEntityType(query).then((result: any) => {
       this.props.updateMetrics(result);
     });
   };

--- a/src/components/Metric/Metric.tsx
+++ b/src/components/Metric/Metric.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BUILT_IN_METRICS, CUSTOM_METRICS, ANALYZE_APPLICATION_METRICS } from '../../GlobalVariables';
+import { BUILT_IN_METRICS, CUSTOM_METRICS, ANALYZE_APPLICATION_METRICS,INFRASTRUCTURE_ANALYZE } from '../../GlobalVariables';
 import { DataSource } from '../../datasources/DataSource';
 import { InstanaQuery } from '../../types/instana_query';
 import max_metrics from '../../lists/max_metrics';
@@ -125,7 +125,7 @@ export default class Metric extends React.Component<Props, MetricState> {
   }
 
   render() {
-    const { query, datasource } = this.props;
+    const { query, datasource } = this.props;   
 
     return (
       <div className={'gf-form'}>
@@ -185,17 +185,19 @@ export default class Metric extends React.Component<Props, MetricState> {
           />
         )}
 
-        <FormSelect
-          queryKeyword
-          disabled={datasource.availableTimeIntervals.length <= 1}
-          labelWidth={5}
-          inputWidth={12}
-          label={'Rollup'}
-          tooltip={'Select the rollup value.'}
-          value={query.timeInterval}
-          options={datasource.availableTimeIntervals}
-          onChange={this.onTimeIntervalChange}
-        />
+        {query.metricCategory.key !== INFRASTRUCTURE_ANALYZE &&(
+          <FormSelect
+            queryKeyword
+            disabled={datasource.availableTimeIntervals.length <= 1}
+            labelWidth={5}
+            inputWidth={12}
+            label={'Rollup'}
+            tooltip={'Select the rollup value.'}
+            value={query.timeInterval}
+            options={datasource.availableTimeIntervals}
+            onChange={this.onTimeIntervalChange}
+         />
+        )}
       </div>
     );
   }

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -152,10 +152,14 @@ export class QueryEditor extends PureComponent<Props, QueryState> {
 
     if (query.entityQuery) {
       datasource.fetchTypesForTarget(query).then((response: any) => {
-        this.snapshots = response.data.plugins;
+        console.log("response2222",response)
+        this.snapshots = response.map((plugin:any)=> plugin.label);
+        console.log('this.snapshots',this.snapshots);
+        
         this.filterForEntityType(true, filterResult);
         onRunQuery();
       });
+      console.log(query, 'query');
     } else {
       this.setState({ queryTypes: [] });
     }
@@ -365,9 +369,10 @@ export class QueryEditor extends PureComponent<Props, QueryState> {
 
   render() {
     const { query, onCategoryChange } = this;
-    const categories = this.allowInfraExplore
-      ? metricCategories
-      : metricCategories.filter((category) => category.key !== INFRASTRUCTURE_ANALYZE);
+    const categories = metricCategories;
+    // const categories = this.allowInfraExplore
+    //   ? metricCategories
+    //   : metricCategories.filter((category) => category.key !== INFRASTRUCTURE_ANALYZE);
 
     return (
       <div className={'gf-form-group'}>
@@ -412,12 +417,12 @@ export class QueryEditor extends PureComponent<Props, QueryState> {
         {query.metricCategory.key === INFRASTRUCTURE_ANALYZE && (
           <Explore
             query={query}
-            queryTypes={this.state.queryTypes}
-            datasource={this.props.datasource}
             onRunQuery={this.props.onRunQuery}
             onChange={this.props.onChange}
             updateMetrics={this.updateMetrics}
-            updateQueryTypes={this.updateQueryTypes}
+            groups={this.state.groups}
+            updateGroups={this.updateGroups}
+            datasource={this.props.datasource}
           />
         )}
 
@@ -478,7 +483,7 @@ export class QueryEditor extends PureComponent<Props, QueryState> {
           />
         )}
 
-        {query.metricCategory.key !== SLO_INFORMATION && query.metricCategory.key !== INFRASTRUCTURE_ANALYZE && (
+        {query.metricCategory.key !== SLO_INFORMATION && (
           <Metric
             query={query}
             onChange={this.props.onChange}
@@ -502,7 +507,8 @@ export class QueryEditor extends PureComponent<Props, QueryState> {
 
         {(query.metricCategory.key === ANALYZE_APPLICATION_METRICS ||
           query.metricCategory.key === ANALYZE_WEBSITE_METRICS ||
-          query.metricCategory.key === ANALYZE_MOBILE_APP_METRICS) && (
+          query.metricCategory.key === ANALYZE_MOBILE_APP_METRICS || 
+          query.metricCategory.key === INFRASTRUCTURE_ANALYZE ) && (
           <Filters
             query={query}
             onChange={this.props.onChange}

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -127,7 +127,7 @@ export class QueryEditor extends PureComponent<Props, QueryState> {
     this.props.onChange(this.query);
   }
 
-  updateMetrics = (metrics: SelectableValue[]) => {
+  updateMetrics = (metrics: SelectableValue[]) => {   
     this.setState({
       availableMetrics: _.sortBy(metrics, 'key'),
       allMetrics: _.sortBy(metrics, 'key'),
@@ -152,14 +152,10 @@ export class QueryEditor extends PureComponent<Props, QueryState> {
 
     if (query.entityQuery) {
       datasource.fetchTypesForTarget(query).then((response: any) => {
-        console.log("response2222",response)
-        this.snapshots = response.map((plugin:any)=> plugin.label);
-        console.log('this.snapshots',this.snapshots);
-        
+        this.snapshots = response.map((plugin: any) => plugin.label);
         this.filterForEntityType(true, filterResult);
         onRunQuery();
       });
-      console.log(query, 'query');
     } else {
       this.setState({ queryTypes: [] });
     }
@@ -370,9 +366,6 @@ export class QueryEditor extends PureComponent<Props, QueryState> {
   render() {
     const { query, onCategoryChange } = this;
     const categories = metricCategories;
-    // const categories = this.allowInfraExplore
-    //   ? metricCategories
-    //   : metricCategories.filter((category) => category.key !== INFRASTRUCTURE_ANALYZE);
 
     return (
       <div className={'gf-form-group'}>
@@ -507,8 +500,7 @@ export class QueryEditor extends PureComponent<Props, QueryState> {
 
         {(query.metricCategory.key === ANALYZE_APPLICATION_METRICS ||
           query.metricCategory.key === ANALYZE_WEBSITE_METRICS ||
-          query.metricCategory.key === ANALYZE_MOBILE_APP_METRICS || 
-          query.metricCategory.key === INFRASTRUCTURE_ANALYZE ) && (
+          query.metricCategory.key === ANALYZE_MOBILE_APP_METRICS) && (
           <Filters
             query={query}
             onChange={this.props.onChange}

--- a/src/datasources/DataSource.ts
+++ b/src/datasources/DataSource.ts
@@ -337,6 +337,9 @@ export class DataSource extends DataSourceApi<InstanaQuery, InstanaOptions> {
   fetchMobileapp(): Promise<SelectableValue[]> {
     return this.dataSourceMobileapp.getMobileapp(this.getTimeFilter());
   }
+  fetchMetricsForEntityType(target:InstanaQuery): Promise<SelectableValue[]> {
+    return this.dataSourceInfrastructure.fetchAvailableMetricsForEntityType(target, this.timeFilter)
+  }
 
   getDefaultTimeInterval(query: InstanaQuery) {
     const category = query.metricCategory.key;

--- a/src/datasources/DataSource.ts
+++ b/src/datasources/DataSource.ts
@@ -318,10 +318,6 @@ export class DataSource extends DataSourceApi<InstanaQuery, InstanaOptions> {
     return this.dataSourceApplication.getApplicationTags(this.getTimeFilter());
   }
 
-  fetchAnalyzetages() {
-    return this.dataSourceInfrastructure.getAnalyzeTags(this.getTimeFilter());
-  }
-
   fetchServices(target: InstanaQuery) {
     return this.dataSourceService.getServicesOfApplication(target, this.getTimeFilter());
   }

--- a/src/datasources/DataSource.ts
+++ b/src/datasources/DataSource.ts
@@ -318,6 +318,10 @@ export class DataSource extends DataSourceApi<InstanaQuery, InstanaOptions> {
     return this.dataSourceApplication.getApplicationTags(this.getTimeFilter());
   }
 
+  fetchAnalyzetages() {
+    return this.dataSourceInfrastructure.getAnalyzeTags(this.getTimeFilter());
+  }
+
   fetchServices(target: InstanaQuery) {
     return this.dataSourceService.getServicesOfApplication(target, this.getTimeFilter());
   }

--- a/src/datasources/DataSource_Application.ts
+++ b/src/datasources/DataSource_Application.ts
@@ -100,7 +100,6 @@ export class DataSourceApplication {
 
     return getRequest(this.instanaOptions, '/api/application-monitoring/applications?' + queryParameters).then(
       (response: any) => {
-        console.log(response, 'response');
         results.push(response.data);
         if (page * pageSize < response.data.totalHits) {
           page++;
@@ -190,7 +189,6 @@ export class DataSourceApplication {
         aggregation: target.aggregation && target.aggregation.key ? target.aggregation.key : 'SUM',
         granularity: target.timeInterval.key,
       };
-
       const group: any = {
         groupbyTag: target.group.key,
       };

--- a/src/datasources/DataSource_Application.ts
+++ b/src/datasources/DataSource_Application.ts
@@ -100,6 +100,7 @@ export class DataSourceApplication {
 
     return getRequest(this.instanaOptions, '/api/application-monitoring/applications?' + queryParameters).then(
       (response: any) => {
+        console.log(response, 'response');
         results.push(response.data);
         if (page * pageSize < response.data.totalHits) {
           page++;

--- a/src/datasources/DataSource_Application.ts
+++ b/src/datasources/DataSource_Application.ts
@@ -189,6 +189,7 @@ export class DataSourceApplication {
         aggregation: target.aggregation && target.aggregation.key ? target.aggregation.key : 'SUM',
         granularity: target.timeInterval.key,
       };
+      
       const group: any = {
         groupbyTag: target.group.key,
       };

--- a/src/datasources/Datasource_Infrastructure.test.ts
+++ b/src/datasources/Datasource_Infrastructure.test.ts
@@ -155,7 +155,7 @@ describe('Given an infrastructure datasource', () => {
             Authorization: 'apiToken ' + options.apiToken,
           },
         })
-        .then((catalog: any) => {        
+        .then((catalog: any) => {
           mockCatalogResponseAndVerify(catalog, metricCategory);
           mockCatalogResponseAndVerify(catalog, metricCategory);
           expect(catalogSpy).toBeCalledTimes(1);
@@ -174,7 +174,7 @@ describe('Given an infrastructure datasource', () => {
     const snapshotB = { status: 200, data: { label: 'label for B' } };
     const contexts = {
       status: 200,
-      data:{
+      data: {
         items: [
           {
             snapshotId: 'A',
@@ -185,7 +185,7 @@ describe('Given an infrastructure datasource', () => {
             host: '',
           },
         ],
-      }
+      },
     };
 
     beforeEach(() => {
@@ -194,7 +194,11 @@ describe('Given an infrastructure datasource', () => {
       contextSpy.mockImplementation((instanaOptions: InstanaOptions, endpoint: string) => {
         if (
           endpoint ===
-          '/api/infrastructure-monitoring/snapshots?plugin='+target.entityType.key+'&size=100&q='+target.entityQuery+'&from=' +
+          '/api/infrastructure-monitoring/snapshots?plugin=' +
+            target.entityType.key +
+            '&size=100&q=' +
+            target.entityQuery +
+            '&from=' +
             timeFilter.from +
             '&to=' +
             timeFilter.to

--- a/src/datasources/Datasource_Infrastructure.test.ts
+++ b/src/datasources/Datasource_Infrastructure.test.ts
@@ -325,7 +325,7 @@ describe('Given an infrastructure datasource', () => {
     });
   });
 
-  describe('when fetching entities for infrastructure analyze', ()=>{
+  describe('when fetching entities for infrastructure analyze', () => {
     let metricSpy: any = jest.spyOn(RequestHandler, 'postRequest');
     const timeFilter: TimeFilter = buildTimeFilter();
     const target: InstanaQuery = buildTestTarget();
@@ -334,107 +334,69 @@ describe('Given an infrastructure datasource', () => {
       data: {
         items: [
           {
-            tags:{},
-            count:1,
+            tags: {},
+            count: 1,
             metrics: {
               "gc.Copy.inv.MAX.60000": [
-              [
-                  1701878640000,
-                  7.0
+                [1701878640000, 7.0],
+                [1701878700000, 4.0],
               ],
-              [
-                  1701878700000,
-                  4.0
-              ]]
-            }
+            },
           },
           {
-            tags:{},
-            count:1,
-            metrics: { }
-          }
-        ]
-      }
+            tags: {},
+            count: 1,
+            metrics: {},
+          },
+        ],
+      },
     };
+  
     beforeEach(() => {
       metricSpy.mockReset();
       metricSpy = jest.spyOn(RequestHandler, 'postRequest');
-      metricSpy.mockImplementation((instanaOptions: InstanaOptions,endpoint: string) => {
+      metricSpy.mockImplementation((instanaOptions: InstanaOptions, endpoint: string) => {
         if (endpoint === '/api/infrastructure-monitoring/analyze/entity-groups') {
           return Promise.resolve(response);
         }
         throw new Error('Unexpected call URL: ' + endpoint);
       });
     });
-    it('should call postRequest with the correct parameters', () => {
-      RequestHandler.postRequest(
+  
+    it('should call postRequest with the correct parameters', async () => {
+      expect(metricSpy).toHaveBeenCalledTimes(0);
+  
+      const windowSize = getWindowSize(timeFilter);
+      const metric: any = {
+        metric: target.metric.key,
+        aggregation: target.aggregation && target.aggregation.key ? target.aggregation.key : 'SUM',
+        granularity: target.timeInterval.key,
+      };
+      const payload = {
+        tagFilterExpression: {
+          elements: [],
+          type: 'EXPRESSION',
+          logicalOperator: 'AND',
+        },
+        pagination: {
+          retrievalSize: 200,
+        },
+        groupBy: [target.groupbyTagSecondLevelKey],
+        type: target.entity.key,
+        metrics: [metric],
+        timeFrame: {
+          to: timeFilter.to,
+          windowSize: atLeastGranularity(windowSize, metric.granularity),
+        },
+      };
+  
+      await dataSourceInfrastructure.fetchAnalyzeEntities(target, timeFilter);
+      expect(RequestHandler.postRequest).toHaveBeenCalledWith(
         dataSourceInfrastructure.instanaOptions,
         '/api/infrastructure-monitoring/analyze/entity-groups',
-        () => {
-          expect(metricSpy).toHaveBeenCalledTimes(1);
-          const windowSize = getWindowSize(timeFilter);
-          const metric: any = {
-            metric: target.metric.key,
-            aggregation: target.aggregation && target.aggregation.key ? target.aggregation.key : 'SUM',
-            granularity: target.timeInterval.key
-          };
-          const payload = {
-            tagFilterExpression:{
-              elements: [],
-              type: "EXPRESSION",
-              logicalOperator: "AND",
-            },
-            pagination: {
-              retrievalSize: 200,
-            },
-            groupBy: [target.groupbyTagSecondLevelKey],
-            type: target.entity.key,
-            metric: [metric],
-            timeFrame: {
-              to: timeFilter.to,
-              windowSize: atLeastGranularity(windowSize, metric.granularity),
-            },
-          };
-          dataSourceInfrastructure.fetchAnalyzeEntities(target, timeFilter);
-          expect(RequestHandler.postRequest).toHaveBeenCalledWith(
-            dataSourceInfrastructure.instanaOptions,
-            '/api/infrastructure-monitoring/analyze/entity-groups',
-            payload
-          );
-        }
+        payload
       );
-    })
-    it('it should return response in correct format', () => {
-      RequestHandler.postRequest(
-        dataSourceInfrastructure.instanaOptions,
-        '/api/infrastructure-monitoring/analyze/entity-groups',
-        ()=> {
-            expect(response.data.items).toHaveProperty('tags');
-            expect(response.data.items[0]).toHaveProperty('count');
-            expect(response.data.items[1]).toHaveProperty('metrics');
-            expect(response.data.items[0]).toEqual({
-              tags:{},
-              count:1,
-              metrics: {
-                "gc.Copy.inv.MAX.60000": [
-                [
-                    1701878640000,
-                    7.0
-                ],
-                [
-                    1701878700000,
-                    4.0
-                ]]
-              },
-            });
-            expect(response.data.items[1]).toEqual({
-              tags:{},
-              count:1,
-              metrics: { },
-            });                            
-        }
-      )
-    }); 
+    });
   });
 
   function resetDataSource() {


### PR DESCRIPTION
- ### Why?

    Infrastructure Analyze  in Grafana Plugin does not have a groupBy or metric field.

- ### What?

  Added Filter fields (groupBy and metric) in Infrastructure Analyze session for avoiding manual filtering

-### Screenshots

 **Before**

<img width="1728" alt="Screenshot 2023-12-11 at 4 42 40 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/7054ba79-9a15-4f4c-a18a-a9872c27eb07">

**After**

<img width="1728" alt="Screenshot 2023-12-11 at 4 42 03 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/7292c447-877c-431b-86d4-033cc3554a5c">
<img width="1728" alt="Screenshot 2023-12-11 at 4 41 42 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/774fcb3d-dbfe-460a-966e-5b31c1cf530f">

- **link to cards**: https://instana.kanbanize.com/ctrl_board/206/cards/113735/details/

