### PR TITLE
Fixing filtering issue in Analyze Application/Website calls

### DIFF
--- a/src/util/analyze_util.test.ts
+++ b/src/util/analyze_util.test.ts
@@ -20,7 +20,7 @@ describe('Given a TagFilter object', () => {
       const expected = {
         name: 'test',
         operator: 'operator',
-        value: false,
+        value: 'string',
       };
 
       expect(createTagFilter(tagFilter)).toEqual(expected);
@@ -28,7 +28,7 @@ describe('Given a TagFilter object', () => {
   });
 
   describe('with NUMBER tag type', () => {
-    it('should return a TagFilter object with the provided numberValue as the string value', () => {
+    it('should return a TagFilter object with the provided numberValue', () => {
       let tagFilter: TagFilter = {
         tag: { key: 'some key', type: 'NUMBER' },
         operator: { key: 'operator' },
@@ -42,7 +42,7 @@ describe('Given a TagFilter object', () => {
       const expected = {
         name: 'some key',
         operator: 'operator',
-        value: false,
+        value: 0,
       };
 
       expect(createTagFilter(tagFilter)).toEqual(expected);
@@ -50,7 +50,7 @@ describe('Given a TagFilter object', () => {
   });
 
   describe('with BOOLEAN tag type', () => {
-    it('should return a TagFilter object with the provided booleanValue as the string value', () => {
+    it('should return a TagFilter object with the provided booleanValue', () => {
       let tagFilter: TagFilter = {
         tag: { key: 'tagKey', type: 'BOOLEAN' },
         operator: { key: 'operator' },

--- a/src/util/analyze_util.ts
+++ b/src/util/analyze_util.ts
@@ -2,16 +2,22 @@ import TagFilter from '../types/tag_filter';
 import _ from 'lodash';
 import { InstanaQuery } from '../types/instana_query';
 
+interface CustomTagFilter {
+  name: string;
+  operator: string;
+  value: string | boolean | number;
+}
+
 export function createTagFilter(filter: TagFilter) {
-  let tagFilter = {
+  let tagFilter: CustomTagFilter = {
     name: filter.tag.key,
     operator: filter.operator.key,
-    value: false,
+    value: filter.stringValue,
   };
 
   if ('NUMBER' === filter.tag.type) {
     if (filter.numberValue !== null) {
-      tagFilter.value = filter.numberValue !== 0;
+      tagFilter.value = filter.numberValue;
     }
   } else if ('BOOLEAN' === filter.tag.type) {
     tagFilter.value = filter.booleanValue;


### PR DESCRIPTION
> ### Why?

 CSP TS014962178: Filter on Endpoint name for "Analyze Application Calls" does not work in Grafana plugin 3.3.9

> ### What?

- Fixing filtering issue in Analyze Application calls 

> ### Screenshots

<img width="1728" alt="Screenshot 2023-12-14 at 4 17 57 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/64ccd788-67ae-429f-b77b-b9a025bb8a2d">
<img width="1728" alt="Screenshot 2023-12-14 at 4 17 49 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/8d7f3c62-27c8-4066-8ca3-5a6c9a502536">
<img width="1727" alt="Screenshot 2023-12-14 at 4 17 39 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/3584285a-c9af-4f18-a7f1-ab4a4759ae9a">
<img width="1728" alt="Screenshot 2023-12-14 at 4 17 29 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/e803447a-adc1-4b55-bb9c-023ad3b213f3">
<img width="1728" alt="Screenshot 2023-12-14 at 4 17 19 PM" src="https://github.com/instana/instana-grafana-datasource/assets/140109309/4f9d0298-0bbe-45ea-a8be-a4c1c5870778">


>  **link to cards**: https://instana.kanbanize.com/ctrl_board/206/cards/148791/details/

