### PR TITLE
Fix docker build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "grafana-toolkit plugin:test",
     "dev": "grafana-toolkit plugin:dev",
     "watch": "grafana-toolkit plugin:dev --watch",
-    "up": "docker-compose up --build",
+    "up": "docker compose up --build",
     "down": "docker-compose down --remove-orphans",
     "start": "yarn up -d; yarn watch",
     "format": "prettier src/**/*.ts --write"


### PR DESCRIPTION
>###Why?

Build failure occurs due to the depreciated docker compose command : `docker-compose` to `docker compose`


>###What?

Fix: .Fix Build Failure issue






