### PR TITLE
Fix docker image deprecation issue

### DIFF
--- a/specs/mb/Dockerfile
+++ b/specs/mb/Dockerfile
@@ -1,4 +1,4 @@
-FROM cpoepke/mountebank-basis:latest
+FROM bbyars/mountebank:latest
 
 ADD imposters /mb/
 


### PR DESCRIPTION


**Build failure occurred during version bump to 4.1.4 due to the use of a deprecated Docker Schema 1 image. To resolve this, we are switching to a modern, Schema 2-compatible Docker image by utilizing the official and up-to-date Mountebank image, which is built using Schema 2.**

